### PR TITLE
version 0.8.0

### DIFF
--- a/README-EMACS.org
+++ b/README-EMACS.org
@@ -1,0 +1,1465 @@
+#+title: duckdb-query.el - Query Anything, Get Elisp
+#+options: ^:nil
+
+# ================
+
+=This version is for usage inside of emacs=
+=without all the html getting in the way=
+
+# ================
+
+#+begin_src elisp :results code
+(let ((carriers '(((code . "UA") (name . "United Airlines"))
+                  ((code . "AA") (name . "American Airlines"))
+                  ((code . "DL") (name . "Delta Air Lines")))))
+  (duckdb-query
+   "SELECT c.name AS airline,
+           COUNT(*) AS flights,
+           ROUND(AVG(f.arr_delay), 1) AS avg_delay
+    FROM read_parquet(@val:url) f
+    JOIN @data:carriers c ON f.carrier = c.code
+    WHERE f.month BETWEEN @val:from_month AND @val:to_month
+    GROUP BY c.name
+    ORDER BY flights DESC"
+   :data `((carriers . ,carriers))
+   :val '((url . "https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet")
+          (from_month . 6) (to_month . 8))
+   :format :columnar))
+
+;; => ((airline . ["United Airlines" "Delta Air Lines" "American Airlines"])
+;;     (flights . [15165 12695 8495])
+;;     (avg_delay . [8.9 9.6 2.8]))
+#+end_src
+
+DuckDB is an embedded analytical database that reads Parquet, CSV, and JSON
+directly from local paths, HTTP URLs, or cloud storage. This package makes
+DuckDB's capabilities available to Elisp programs. The ~duckdb-query~ function
+executes SQL and returns alists, plists, vectors, or org-table-compatible lists.
+Results are ready for ~mapcar~, ~seq-filter~, ~cl-loop~, or direct insertion into
+buffers.
+
+The package treats all data sources uniformly. Elisp alists become SQL tables
+via the ~:data~ parameter. Named org tables in your buffer resolve through
+~@org:table-name~ syntax. These combine freely with file paths and URLs in joins,
+unions, and subqueries. A query can join a remote Parquet file with a ten-row
+org table and a runtime Elisp variable, returning the result as an alist you can
+immediately process.
+
+* Quick Examples
+:PROPERTIES:
+:CUSTOM_ID: quick-examples
+:END:
+
+#+begin_src elisp :results code
+;; List of alists (default)
+(duckdb-query
+ "SELECT name:'Alice', score:95
+  UNION ALL
+    SELECT 'Bob', 87")
+;; => (((name . "Alice") (score . 95))
+;;     ((name . "Bob") (score . 87)))
+#+end_src
+
+#+begin_src elisp :results code
+;; Single value extraction
+(duckdb-query
+ "FROM range(1000)
+  SELECT COUNT(*)"
+ :format :single)
+;; => 1000
+#+end_src
+
+#+begin_src elisp :results code
+;; Single row as alist
+(duckdb-query
+ "SELECT name:'Alice',
+         score: 95,
+         grade: 'A'"
+ :format :row)
+;; => ((name . "Alice") (score . 95) (grade . "A"))
+#+end_src
+
+#+begin_src elisp :results code
+;; Single column as list
+(duckdb-query
+ "SELECT
+     unnest(['red','green','blue'])
+  as color"
+ :format :column)
+;; => ("red" "green" "blue")
+#+end_src
+
+#+begin_src elisp
+;; Org-table format for display
+(duckdb-query
+ "FROM range(1,4) t(n),
+ (SELECT letter: unnest(['a','b']))"
+ :format :org-table)
+;; => ((n letter) (1 "a") (2 "a") (3 "a") (1 "b") (2 "b") (3 "b"))
+#+end_src
+
+#+begin_src elisp :results code
+;; Columnar format for analysis
+(duckdb-query
+ "SELECT n, n * 2 as doubled
+  FROM range(5) t(n)"
+ :format :columnar)
+;; => ((n . [0 1 2 3 4]) (doubled . [0 2 4 6 8]))
+#+end_src
+
+#+begin_src elisp :results code
+;; Safe parameterization with @val:
+(duckdb-query
+ "SELECT * FROM range(10) t(n)
+  WHERE n > @val:threshold"
+ :val '((threshold . 5))
+ :format :column)
+;; => (6 7 8 9)
+#+end_src
+
+#+begin_src elisp :results code
+;; Query fragment composition
+(duckdb-query
+ "SELECT * FROM (@sql:source)
+  WHERE n > 2"
+ :sql '((source .
+         "SELECT * FROM range(5) t(n)"))
+ :format :column)
+;; => (3 4)
+#+end_src
+
+For advanced parameterization including computed thresholds, sequential variable
+dependencies, and fragment composition with embedded references, see
+[[#parameterized-queries][Parameterized Queries]].
+* Contents :noexport:
+:PROPERTIES:
+:TOC:      :include siblings :depth 1 :ignore this
+:END:
+:CONTENTS:
+- [[#installation][Installation]]
+- [[#configuration][Configuration]]
+- [[#querying-elisp-data][Querying Elisp Data]]
+- [[#querying-org-tables][Querying Org Tables]]
+- [[#combining-sources][Combining Sources]]
+- [[#parameterized-queries][Parameterized Queries]]
+- [[#output-formats][Output Formats]]
+- [[#schema-introspection][Schema Introspection]]
+- [[#database-persistence][Database Persistence]]
+- [[#session-based-execution][Session-Based Execution]]
+- [[#nested-types][Nested Types]]
+- [[#performance][Performance]]
+- [[#font-lock-for-reference-syntax][Font Lock for Reference Syntax]]
+- [[#sql-completion][SQL Completion]]
+- [[#acknowledgements][Acknowledgements]]
+- [[#related-packages][Related Packages]]
+- [[#integration][Integration]]
+:END:
+
+* Installation
+:PROPERTIES:
+:CUSTOM_ID: installation
+:END:
+duckdb-query is available on MELPA. Install with =M-x package-install= ⏎ =duckdb-query=.
+Requires the =duckdb= CLI executable in your PATH. Install from [[https://duckdb.org/docs/installation/][duckdb.org]] or via package manager:
+
+#+begin_src shell
+brew install duckdb # macOS
+sudo apt install duckdb # Ubuntu/Debian
+# Or download directly from duckdb.org
+#+end_src
+
+- MELPA (recommended) ::
+#+begin_src emacs-lisp
+(use-package duckdb-query
+  :ensure t)
+#+end_src
+
+- use-package with vc (Emacs 30+) ::
+#+begin_src emacs-lisp
+(use-package duckdb-query
+  :vc (:url "https://github.com/gggion/duckdb-query.el"
+       :rev :newest))
+#+end_src
+
+- Straight or Elpaca ::
+#+begin_src emacs-lisp
+(straight-use-package 'duckdb-query)
+;; OR
+(elpaca duckdb-query)
+#+end_src
+
+The core =duckdb-query= function works immediately after installation.  For
+optional editor enhancements (syntax highlighting and completion inside SQL
+strings), see [[#configuration][Configuration]].
+* Configuration
+:PROPERTIES:
+:CUSTOM_ID: configuration
+:END:
+
+The package works out of the box with sensible defaults. The =duckdb-query=
+function requires no configuration. See =M-x customize-group RET duckdb-query RET=
+for all options.
+
+** Key Variables
+
+- ~duckdb-query-executable~ : Path to DuckDB CLI (default: ="duckdb"=)
+- ~duckdb-query-default-timeout~ : Query timeout in seconds (default: =30=)
+- ~duckdb-query-null-value~ : Elisp representation of SQL NULL (default: =:null=)
+- ~duckdb-query-false-value~ : Elisp representation of SQL FALSE (default: =:false=)
+
+** Editor Support for SQL Strings (Optional)
+
+Two optional minor modes enhance editing =duckdb-query= SQL strings. These are
+not required for the package to function but improve the development experience
+when writing queries in Elisp or Org buffers:
+
+- ~duckdb-query-font-lock-mode~ : Highlights =@type:name= references with
+  validation. Invalid references (undefined bindings, invalid context) show a
+  warning face. Works in =emacs-lisp-mode= buffers and inside org-mode src
+  blocks.
+
+- ~duckdb-query-complete-mode~ : Provides completion-at-point for reference
+  names, SQL keywords, functions, and types. Works with corfu, company-mode, and
+  the default completion UI. In org-mode, narrows to the current src block for
+  efficient parsing.
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-query-font-completion.png?raw=true" align="center" width="100%">
+#+HTML: <p align="center"><em>Example with both modes enabled, autocompletion and custom reference highlights</em></p>
+
+Both modes are independent and share the same structural parser.
+
+*** Enabling via use-package
+
+#+begin_src emacs-lisp
+(use-package duckdb-query
+  :ensure t
+  :config
+  (add-hook 'emacs-lisp-mode-hook #'duckdb-query-font-lock-mode)
+  (add-hook 'emacs-lisp-mode-hook #'duckdb-query-complete-mode)
+  (add-hook 'org-mode-hook #'duckdb-query-complete-mode))
+#+end_src
+
+*** Enabling Manually
+
+#+begin_src emacs-lisp
+;; Highlight @type:name references with validation
+(add-hook 'emacs-lisp-mode-hook #'duckdb-query-font-lock-mode)
+
+;; Complete reference names, SQL keywords, functions, and types
+(add-hook 'emacs-lisp-mode-hook #'duckdb-query-complete-mode)
+(add-hook 'org-mode-hook #'duckdb-query-complete-mode)
+#+end_src
+
+Adding ~duckdb-query-font-lock-mode~ to =emacs-lisp-mode-hook= also highlights
+references inside org-mode =emacs-lisp= src blocks automatically. In org's
+fontification buffers, the mode activates with minimal overhead. To disable
+highlighting in org src blocks entirely:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-font-lock-in-org-src-blocks nil)
+#+end_src
+
+*** Performance in Large Buffers
+
+Both modes accept buffer size thresholds. When set, the modes skip their
+expensive operations in buffers exceeding the threshold:
+
+#+begin_src emacs-lisp
+;; Skip reference fontification in large buffers
+(setq duckdb-query-font-lock-max-buffer-size 512000)  ; 500KB
+
+;; Skip completion in large buffers
+(setq duckdb-query-complete-max-buffer-size 512000)    ; 500KB
+#+end_src
+
+For font-lock, the threshold applies to both standalone =.el= files and the org
+buffer that triggered src block fontification. For completion, the threshold
+applies to the buffer where completion is invoked.
+
+*** Completion Trigger Behavior
+
+The completion mode provides candidates when triggered. Whether candidates
+appear automatically on each keypress or only on explicit invocation depends
+on your completion framework:
+
+| Framework | Automatic (on keypress)    | Manual trigger      |
+|-----------+----------------------------+---------------------|
+| Corfu     | ~corfu-auto~ non-nil         | ~completion-at-point~ |
+| Company   | ~company-idle-delay~ non-nil | ~company-complete~    |
+| Default   | N/A (always manual)        | =C-M-i=               |
+
+To suppress SQL keyword/function completion during automatic (idle) completion
+while keeping it available on explicit invocation:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-complete-trigger 'manual)
+#+end_src
+
+With this setting, SQL metadata candidates only appear when you explicitly
+invoke completion. Reference completion (=@type:name=) always activates
+regardless of this setting, since typing =@= is already an explicit action.
+
+*** Customizing Completion Behavior
+
+The completion mode queries DuckDB metadata once at enable time and caches
+approximately 3400 candidates (keywords, functions, types). To refresh after
+loading extensions or attaching databases:
+
+#+begin_src
+M-x duckdb-query-complete-refresh-cache
+#+end_src
+
+To disable SQL metadata completion and keep only reference completion:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-complete-sql-p nil)
+#+end_src
+
+See [[#font-lock-for-reference-syntax][Font Lock for Reference Syntax]] and [[#sql-completion][SQL Completion]] for full documentation.
+
+- Org-Mode Src Blocks ::
+In org-mode, the completion mode narrows to the current =emacs-lisp= or
+=elisp= src block body and switches to ~emacs-lisp-mode-syntax-table~
+before parsing. This ensures correct syntax context and avoids scanning the
+entire org buffer. Completion only activates when point is inside a recognized
+src block.
+
+* Querying Elisp Data
+:PROPERTIES:
+:CUSTOM_ID: querying-elisp-data
+:END:
+
+Pass Elisp alists to queries via the ~:data~ parameter. The data becomes a table
+named ~@data~:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT name, score * 1.1 as curved
+  FROM @data
+  WHERE score > 85"
+ :data '(((name . "Aly") (score . 95))
+         ((name . "Bob") (score . 87))
+         ((name . "Carol") (score . 72))))
+;; => (((name . "Aly") (curved . 104.5))
+;;     ((name . "Bob") (curved . 95.7)))
+#+end_src
+
+For multiple tables, use named bindings with backquote to capture lexical
+variables:
+
+#+begin_src elisp :results code
+(let ((users
+       '(((id . 1) (name . "Alice"))
+         ((id . 2) (name . "Bob"))))
+      (orders
+       '(((user_id . 1) (item . "Widget"))
+         ((user_id . 2) (item . "Gadget"))
+         ((user_id . 1) (item . "Gizmo")))))
+  (duckdb-query
+   "SELECT u.name, COUNT(*) as count
+    FROM @users u
+    JOIN @orders o ON u.id = o.user_id
+    GROUP BY u.name"
+   :data `((users . ,users)
+           (orders . ,orders))))
+;; => (((name . "Alice") (count . 2))
+;;     ((name . "Bob") (count . 1)))
+#+end_src
+
+This enables joining runtime Elisp state with static file data. Previously this
+required exporting to CSV, running an external query, and parsing results. Now
+it is one expression.
+
+* Querying Org Tables
+:PROPERTIES:
+:CUSTOM_ID: querying-org-tables
+:END:
+
+Reference named org tables with ~@org:table-name~. Given this table in your
+buffer:
+
+#+NAME: inventory
+| sku   | product | stock | price |
+|-------+---------+-------+-------|
+| A-100 | Widget  |    50 |  9.99 |
+| B-200 | Gadget  |    30 | 24.99 |
+| C-300 | Gizmo   |    75 | 14.99 |
+
+#+begin_src elisp
+(duckdb-query
+ "SELECT product,
+    (stock * price)::DECIMAL as value
+  FROM @org:inventory
+  ORDER BY value DESC"
+ :format :org-table)
+;; => ((product value) ("Gizmo" 1124.25) ("Gadget" 749.7) ("Widget" 499.5))
+#+end_src
+
+#+RESULTS:
+| product |   value |
+| Gizmo   | 1124.25 |
+| Gadget  |   749.7 |
+| Widget  |   499.5 |
+
+Reference tables in other files with ~@org:path/to/file.org:table-name~.
+
+* Combining Sources
+:PROPERTIES:
+:CUSTOM_ID: combining-sources
+:END:
+
+Join an org table with Elisp data:
+
+#+begin_src elisp :results code
+(let ((sales '(((sku . "A-100") (qty . 10))
+               ((sku . "A-100") (qty . 5))
+               ((sku . "C-300") (qty . 20)))))
+  (duckdb-query
+   "SELECT i.product,
+           SUM(s.qty) as sold,
+           i.stock - SUM(s.qty) as remaining
+    FROM @org:inventory i
+    JOIN @data:sales s ON i.sku = s.sku
+    GROUP BY i.product, i.stock"
+   :data `((sales . ,sales))))
+;; => (((product . "Widget") (sold . 15) (remaining . 35))
+;;     ((product . "Gizmo") (sold . 20) (remaining . 55)))
+#+end_src
+
+
+Join a remote Parquet file with local Elisp data:
+
+#+begin_src elisp :results code
+(let ((airports '(((code . "JFK") (name . "JFK International"))
+                  ((code . "LGA") (name . "LaGuardia")))))
+  (duckdb-query
+   "SELECT a.name,
+           COUNT(*) as departures,
+           ROUND(AVG(f.dep_delay), 1) as avg_delay
+    FROM 'https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet' f
+    JOIN @data:airports a ON f.origin = a.code
+    GROUP BY a.name
+    ORDER BY departures DESC"
+   :data `((airports . ,airports))))
+
+;; => (((name . "JFK International") (departures . 111279) (avg_delay . 12.1))
+;;     ((name . "LaGuardia") (departures . 104662) (avg_delay . 10.3)))
+#+end_src
+
+
+Here's an example combining ~@data~, ~@org~ and ~@val~ in a single query using the
+same ~inventory~ table from the previous section:
+
+#+begin_src elisp :results code
+;; Using #+NAME: inventory from above
+(let ((sales '(((sku . "A-100") (qty . 15))
+               ((sku . "C-300") (qty . 25)))))
+  (duckdb-query
+   "SELECT i.product,
+           s.qty as sold,
+           s.qty * i.price as revenue
+    FROM @org:inventory i
+    JOIN @data:sales s ON i.sku = s.sku
+    WHERE i.price >= @val:min_price
+    ORDER BY revenue DESC"
+   :data `((sales . ,sales))
+   :val '((min_price . 10))))
+;; => (((product . "Gizmo") (sold . 25) (revenue . 374.75))
+;;     ((product . "Widget") (sold . 15) (revenue . 149.85)))
+#+end_src
+
+* Parameterized Queries
+:PROPERTIES:
+:CUSTOM_ID: parameterized-queries
+:END:
+
+The package provides parameterization through the =@type:name= reference pattern.
+All references follow the same syntax but serve different purposes and have
+different safety characteristics.
+
+** Reference Type Summary
+:PROPERTIES:
+:CUSTOM_ID: reference-type-summary
+:END:
+
+| Type   | Syntax              | Parameter | Mechanism                      | Use Case                        |
+|--------+---------------------+-----------+--------------------------------+---------------------------------|
+| =@org:=  | =@org:table=          | --        | Resolve org table to JSON file | Org table data                  |
+|        | =@org:file:table=     |           |                                | Org table from specific file    |
+| =@data:= | =@data:name= or =@name= | =:data=     | Serialize Elisp to JSON file   | Elisp data structures           |
+| =@val:=  | =@val:name=           | =:val=      | =SET VARIABLE= with SQL literal  | Literal values (injection-safe) |
+| =@sql:=  | =@sql:name=           | =:sql=      | Direct text substitution       | Query fragments, identifiers    |
+
+The reference type in your query must match the parameter:
+- =@val:x= requires =x= to be in =:val=
+- =@sql:x= requires =x= to be in =:sql=
+- =@data:x= requires =x= to be in =:data=
+
+Mismatches signal an error with a helpful message indicating which parameter is missing.
+
+** Substitution Order
+
+References are processed in strict order, enabling powerful composition:
+
+1. =@sql:= -- Text substitution first (fragments can contain other reference types)
+2. =@org:= -- Org tables resolved to temp JSON files
+3. =@data:= -- Elisp data serialized to temp JSON files
+4. =@val:= -- Variable bindings generated as =SET VARIABLE= statements
+
+This ordering is critical: =@sql:= fragments can contain =@val:=, =@data:=, and =@org:=
+references that resolve in subsequent passes.
+
+** Variable Binding with =@val:=
+
+The =:val= parameter binds Elisp values as DuckDB session variables. Values are
+converted to SQL literals with proper escaping, making this safe for user input:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT * FROM users
+  WHERE name LIKE @val:pattern
+    AND age >= @val:min_age"
+ :val '((pattern . "%O'Brien%")
+        (min_age . 18)))
+#+end_src
+
+Equivalent to:
+#+begin_src sql
+SET VARIABLE pattern = '%O''Brien%';
+SET VARIABLE min_age = 18;
+SELECT * FROM users
+WHERE name LIKE getvariable('pattern')
+  AND age >= getvariable('min_age')
+#+end_src
+
+Variables support all DuckDB types with automatic conversion:
+
+| Elisp Value          | SQL Generated    | DuckDB Type |
+|----------------------+------------------+-------------|
+| =42=                   | =42=               | INTEGER     |
+| =3.14159=              | =3.14159=          | DOUBLE      |
+| ="O'Brien"=            | ='O''Brien'=       | VARCHAR     |
+| =t=                    | =TRUE=             | BOOLEAN     |
+| =:false=               | =FALSE=            | BOOLEAN     |
+| =:null= or =nil=         | =NULL=             | NULL        |
+| =[1 2 3]=              | =[1, 2, 3]=        | INTEGER[]   |
+| =((a . 1) (b . 2))=    | ={'a': 1, 'b': 2}= | STRUCT      |
+| =(sql "(SELECT ...)")= | =(SELECT ...)=     | (evaluated) |
+
+Bound values are native DuckDB types, enabling struct field access and array operations:
+
+#+begin_src elisp :results code
+;; Struct field access
+(duckdb-query "SELECT @val:person.name AS n, @val:person.age AS a"
+              :val '((person . ((name . "Alice") (age . 30)))))
+;; => (((n . "Alice") (a . 30)))
+
+;; Array operations
+(duckdb-query "SELECT list_sum(@val:nums) AS total, @val:nums[2] AS second"
+              :val '((nums . [10 20 30])))
+;; => (((total . 60) (second . 20)))
+#+end_src
+
+*** Sequential Variable Dependencies
+
+Bindings are processed in declaration order like =let*=. Later bindings can
+reference earlier ones using the =(sql ...)= wrapper:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT @val:base AS b,
+         @val:doubled AS d,
+         @val:final AS f"
+ :val '((base . 10)
+        (doubled . (sql "@val:base * 2"))
+        (final . (sql "@val:doubled + @val:base"))))
+;; => (((b . 10) (d . 20) (f . 30)))
+#+end_src
+
+The =(sql ...)= wrapper passes its content through unquoted, enabling DuckDB to
+evaluate expressions. Without the wrapper, strings are quoted as literals.
+
+Out-of-order references signal an error:
+
+#+begin_src elisp :results code
+(duckdb-query "SELECT @val:result"
+              :val '((result . (sql "@val:undefined"))
+                     (undefined . 10)))
+;; Error: @val:result in value references undefined variable 'undefined'
+#+end_src
+
+*** Computed Values from Data
+
+The =(sql ...)= expressions can reference =@data:= bindings, enabling dynamic
+thresholds computed from your data:
+
+#+begin_src elisp :results code
+(let ((scores
+       '(((name . "Alice") (score . 90))
+         ((name . "Bob") (score . 70))
+         ((name . "Carol") (score . 85)))))
+  (duckdb-query
+   "SELECT * FROM @data:scores
+    WHERE score > @val:threshold"
+   :data `((scores . ,scores))
+   :val '((threshold
+           . (sql "(SELECT AVG(score)
+                    FROM @data:scores)")))))
+;; => (((name . "Alice") (score . 90)))
+;; Threshold computed as ~81.67
+#+end_src
+
+*** Reference Validity in =(sql ...)= Wrappers
+
+The =(sql ...)= wrapper can contain =@val:= and =@data:= references. However, =@sql:=
+and =@org:= references inside =(sql ...)= cannot be resolved because =@sql:=
+substitution happens before =:val= processing:
+
+| Reference Type | In =(sql ...)= Wrapper |
+|----------------+----------------------|
+| =@val:name=      | Valid                |
+| =@data:name=     | Valid                |
+| =@sql:name=      | Invalid              |
+| =@org:name=      | Invalid              |
+
+#+begin_quote
+[!IMPORTANT]
+Variables are /scalar/ values. They must resolve to exactly one column and one
+row. Subqueries returning multiple columns or rows will error:
+=Binder Error: Subquery returns 2 columns - expected 1=.
+For table-valued data, use =@data:= bindings instead.
+#+end_quote
+
+** Query Fragment Composition with =@sql:=
+
+The =@sql:= reference performs direct text substitution. Use it for query
+fragments, dynamic identifiers, or computed expressions that cannot be
+parameterized as values:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT * FROM (@sql:base_query)
+  WHERE value > @val:threshold"
+ :sql '((base_query .
+         "SELECT n AS id, n * 10 AS value
+          FROM range(1, 6) t(n)"))
+ :val '((threshold . 30)))
+;; => (((id . 4) (value . 40)) ((id . 5) (value . 50)))
+#+end_src
+
+*** Fragments Can Contain Other References
+
+Since =@sql:= substitution happens first, fragments can contain =@val:=, =@data:=, and
+=@org:= references that resolve in subsequent passes:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT * FROM (@sql:filtered_data)"
+ :sql '((filtered_data .
+         "SELECT * FROM @data:users
+          WHERE age > @val:min_age"))
+ :data `((users . ,user-list))
+ :val '((min_age . 21)))
+#+end_src
+
+*** Nested Fragment Substitution
+
+Fragments can reference other fragments, enabling modular query construction:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT * FROM (@sql:outer)"
+ :sql '((outer . "SELECT x, x*2 AS doubled FROM (@sql:inner)")
+        (inner . "SELECT generate_series AS x FROM generate_series(1, 3)")))
+;; => (((x . 1) (doubled . 2)) ((x . 2) (doubled . 4)) ((x . 3) (doubled . 6)))
+#+end_src
+
+*** Dynamic Identifiers
+
+Table names, column names, and other SQL identifiers cannot be parameterized
+with =@val:= (DuckDB treats them as string literals). Use =@sql:= for dynamic
+identifiers:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT @sql:columns
+  FROM @sql:source
+  ORDER BY @sql:sort_col DESC
+  LIMIT @val:n"
+ :sql '((source . "range(1, 100) t(n)")
+        (columns . "n, n * 2 AS doubled")
+        (sort_col . "doubled"))
+ :val '((n . 5)))
+;; => (((n . 99) (doubled . 198))
+;;     ((n . 98) (doubled . 196))
+;;     ((n . 97) (doubled . 194))
+;;     ((n . 96) (doubled . 192))
+;;     ((n . 95) (doubled . 190)))
+#+end_src
+
+*** Reusable Query Libraries
+
+It's also possible to define fragment libraries for common patterns:
+
+#+begin_src elisp :results code
+(defvar my-query-fragments
+  '((active_users . "SELECT * FROM @data:users WHERE status = 'active'")
+    (recent_orders . "SELECT * FROM @data:orders WHERE date > @val:since")))
+
+(let ((users '(((id . 1) (name . "Alice") (status . "active"))
+               ((id . 2) (name . "Bob") (status . "inactive"))
+               ((id . 3) (name . "Carol") (status . "active"))))
+      (orders '(((id . 101) (user_id . 1) (date . "2024-02-15"))
+                ((id . 102) (user_id . 1) (date . "2024-03-01"))
+                ((id . 103) (user_id . 3) (date . "2024-02-20")))))
+  (duckdb-query
+   "SELECT u.name, COUNT(o.id) as order_count
+    FROM (@sql:active_users) u
+    LEFT JOIN (@sql:recent_orders) o ON u.id = o.user_id
+    GROUP BY u.name"
+   :sql my-query-fragments
+   :data `((users . ,users) (orders . ,orders))
+   :val '((since . "2024-01-01"))))
+;; => (((name . "Alice") (order_count . 2))
+;;     ((name . "Carol") (order_count . 1)))
+#+end_src
+
+** Cross-Reference Interaction Guide
+
+This table summarizes which reference types can contain other reference types:
+
+| Container       | Can contain =@sql:= | Can contain =@data:= | Can contain =@val:=  | Can contain =@org:= |
+|-----------------+-------------------+--------------------+--------------------+-------------------|
+| Main query      | Yes               | Yes                | Yes                | Yes               |
+| =@sql:= fragment  | Yes (nested)      | Yes                | Yes                | Yes               |
+| =@val:= =(sql ...)= | No                | Yes                | Yes (earlier only) | No                |
+
+
+
+** Complete Example: All Reference Types
+
+This example demonstrates all binding types working together:
+
+#+begin_src elisp
+(let ((products '(((sku . "A1") (name . "Widget") (price . 29.99))
+                  ((sku . "B2") (name . "Gadget") (price . 49.99))
+                  ((sku . "C3") (name . "Gizmo") (price . 99.99))))
+      (sales '(((sku . "A1") (qty . 10) (region . "West"))
+               ((sku . "B2") (qty . 5) (region . "East"))
+               ((sku . "C3") (qty . 3) (region . "West")))))
+  (duckdb-query
+   "WITH metrics AS (@sql:metrics_cte)
+    SELECT
+      m.region,
+      m.revenue,
+      @val:avg_revenue AS overall_avg,
+      CASE WHEN m.revenue > @val:high_threshold THEN 'High'
+           WHEN m.revenue > @val:avg_revenue THEN 'Medium'
+           ELSE 'Low'
+      END AS performance
+    FROM metrics m
+    ORDER BY m.revenue DESC"
+
+   :sql '((metrics_cte .
+           "SELECT s.region, SUM(s.qty * p.price) AS revenue
+            FROM @data:sales s
+            JOIN @data:products p ON s.sku = p.sku
+            WHERE p.price >= @val:min_price
+            GROUP BY s.region"))
+
+   :data `((products . ,products)
+           (sales . ,sales))
+
+   :val '((min_price . 25)
+          (avg_revenue . (sql "(SELECT AVG(s.qty * p.price)
+                                FROM @data:sales s
+                                JOIN @data:products p ON s.sku = p.sku)"))
+          (high_threshold . (sql "@val:avg_revenue * 1.5")))
+
+   :format :org-table))
+#+end_src
+
+This query:
+- Uses =@sql:metrics_cte= to define a reusable CTE fragment
+- The fragment contains =@data:= and =@val:= references resolved after substitution
+- Computes =avg_revenue= from bound data using =(sql ...)=
+- Derives =high_threshold= from the computed average using sequential dependency
+- Combines all reference types in a single query
+
+* Output Formats
+:PROPERTIES:
+:CUSTOM_ID: output-formats
+:END:
+#+begin_quote
+[!IMPORTANT]
+NEW in 0.8:  ~:single~, ~:row~, and ~:column~ formats
+#+end_quote
+
+The ~:format~ parameter controls result structure:
+
+| Format     | Structure                 | Use Case                      |
+|------------+---------------------------+-------------------------------|
+| ~:alist~     | List of alists            | General Elisp processing      |
+| ~:plist~     | List of plists            | Keyword-based access          |
+| ~:hash~      | List of hash-tables       | O(1) field lookup             |
+| ~:vector~    | Vector of alists          | Index-based access            |
+| ~:columnar~  | Alist of column vectors   | Numerical analysis            |
+| ~:org-table~ | List of lists with header | Display, org-mode integration |
+| ~:single~    | Scalar value              | COUNT, MAX, single lookups    |
+| ~:row~       | Single alist              | Single record extraction      |
+| ~:column~    | List of values            | Single column extraction      |
+| ~:raw~       | JSON string               | Custom parsing                |
+
+The ~:single~, ~:row~, and ~:column~ formats enforce cardinality:
+
+#+begin_src elisp :results code
+;; :single errors on multiple rows/columns
+(duckdb-query
+ "SELECT 1, 2" :format :single)
+;; Error: Query returned 2 columns, expected 1 for :single format
+#+end_src
+
+#+begin_src elisp :results code
+;; :row errors on multiple rows
+(duckdb-query
+ "SELECT * FROM range(3) t(n)"
+ :format :row)
+;; Error: Query returned 3 rows, expected 1 for :row format
+#+end_src
+
+#+begin_src elisp :results code
+;; :column takes first column silently
+(duckdb-query
+ "SELECT n, n*2 FROM range(3) t(n)"
+ :format :column)
+;; => (0 1 2)
+#+end_src
+
+These cardinality checks catch logic bugs early like if you were expecting one
+row but get three, or expected a single column but got several, etc
+
+Additionally, the convenience functions ~duckdb-query-value~, ~duckdb-query-row~,
+and ~duckdb-query-column~ provide the same extraction without ~:format~:
+
+#+begin_src elisp
+(duckdb-query-value "SELECT COUNT(*) FROM range(100)")
+;; => 100
+(duckdb-query-row "SELECT name:'Alice', score:95")
+;; => ((name . "Alice") (score . 95))
+(duckdb-query-column "SELECT unnest([1,2,3])")
+;; => (1 2 3)
+#+end_src
+
+* Schema Introspection
+:PROPERTIES:
+:CUSTOM_ID: schema-introspection
+:END:
+Discover structure before querying:
+
+#+begin_src elisp :results code :exports both
+(duckdb-query-column-types "SELECT 1 as id, 'text' as name, 3.14 as value")
+;; => (("id" . "INTEGER") ("name" . "VARCHAR") ("value" . "DECIMAL(3,2)"))
+#+end_src
+
+#+begin_src elisp :results code :exports both
+(duckdb-query-columns
+ "https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet")
+
+;; => ("year" "month" "day" "dep_time" "sched_dep_time" "dep_delay" "arr_time"
+;;     "sched_arr_time" "arr_delay" "carrier" "flight" "tailnum" "origin" "dest"
+;;     "air_time" "distance" "hour" "minute" "time_hour")
+#+end_src
+
+#+begin_src elisp :results code :exports both
+(duckdb-query-describe "SELECT 1 as id, 'text' as name")
+;; => (((column_name . "id") (column_type . "INTEGER") (null . "YES") ...)
+;;     ((column_name . "name") (column_type . "VARCHAR") (null . "YES") ...))
+#+end_src
+
+* Database Persistence
+:PROPERTIES:
+:CUSTOM_ID: database-persistence
+:END:
+
+For workflows requiring state across queries, bind a database file:
+
+#+begin_src elisp :results code
+(duckdb-query-with-transient-database
+  (duckdb-query
+   "CREATE TABLE events (id INT, name TEXT)")
+  (duckdb-query
+   "INSERT INTO events VALUES
+    (1, 'click'), (2, 'scroll')")
+  (duckdb-query "SELECT * FROM events"))
+;; => (((id . 1) (name . "click"))
+;;     ((id . 2) (name . "scroll")))
+#+end_src
+
+~duckdb-query-with-transient-database~ creates a temporary file deleted after the
+block.  Use ~duckdb-query-with-database~ for persistent files:
+
+#+begin_src elisp :results code
+(duckdb-query-with-database "analytics.duckdb"
+  (duckdb-query "CREATE TABLE events (id INT, name TEXT)")
+  (duckdb-query "INSERT INTO events VALUES (1, 'click')")
+  (duckdb-query "SELECT * FROM events"))
+;; => (((id . 1) (name . "click")))
+#+end_src
+
+Databases open in writable mode by default.  For read-only access, pass a spec
+list with ~:readonly t~:
+
+#+begin_src elisp :results code
+;; Open existing database read-only (prevents accidental writes)
+(duckdb-query-with-database '("analytics.duckdb" :readonly t)
+  (duckdb-query "SELECT * FROM events"))
+#+end_src
+
+#+begin_quote
+[!WARNING]
+When a database path does not exist, DuckDB creates it automatically in
+writable mode.  This means ~:database "new.db"~ or
+~duckdb-query-with-database "new.db"~ will create the file as a side
+effect.  Use ~:readonly t~ to prevent accidental creation -- DuckDB
+signals an error if the file does not exist in read-only mode.
+#+end_quote
+
+The spec list supports variable paths:
+
+#+begin_src elisp :results code
+;; With variable path
+(let ((db-path "~/project/app.db"))
+  (duckdb-query-with-database `(,db-path)
+    (duckdb-query "SELECT * FROM users")))
+
+;; Read-only with variable path
+(let ((db-path "~/project/app.db"))
+  (duckdb-query-with-database `(,db-path :readonly t)
+    (duckdb-query "SELECT * FROM users")))
+#+end_src
+
+The bare ~:database~ parameter in ~duckdb-query~ also defaults to writable:
+
+#+begin_src elisp :results code
+;; Direct parameter -- also writable
+(duckdb-query "SELECT * FROM logs" :database "app.db")
+#+end_src
+
+These macros work with CLI execution.  For persistent processes with lower
+latency, see [[#session-based-execution][Session-Based Execution]] below.
+* Session-Based Execution
+:PROPERTIES:
+:CUSTOM_ID: session-based-execution
+:END:
+For repeated queries or workflows requiring persistent state, sessions eliminate
+DuckDB process spawn overhead (~10-20ms per query). A session maintains a
+long-running DuckDB process with its own temporary database:
+
+#+begin_src elisp :results code
+;; Initialize sessions
+(duckdb-query-session-start "work")
+(duckdb-query-session-start "other-session")
+
+(let ((result-set
+       (list :work-results
+             (duckdb-query-with-session "work"
+               (duckdb-query "CREATE TABLE events AS SELECT i, random() AS value FROM range(1000) t(i)")
+               (duckdb-query "SELECT AVG(value) as average FROM events"))
+             :other-results
+             (duckdb-query-with-session "other-session"
+               (duckdb-query "CREATE TABLE logs AS SELECT i, random() AS value FROM range(10) t(i)")
+               (duckdb-query "SELECT AVG(value) as average FROM logs"))
+             :back-to-work
+             ;; Session state persists across scopes
+             (duckdb-query-with-session "work"
+               (duckdb-query "CREATE TABLE new_table AS SELECT i, random() AS value FROM range(100) t(i)")
+               (duckdb-query "SELECT AVG(value) as average FROM new_table")))))
+
+  ;; Clean up when done
+  (duckdb-query-session-kill "work")
+  (duckdb-query-session-kill "other-session")
+  result-set)
+#+end_src
+
+For temporary sessions that clean up automatically:
+
+#+begin_src elisp :results code
+(duckdb-query-with-transient-session
+  (duckdb-query "CREATE TABLE scratch AS SELECT random() as val FROM range(5)")
+  (duckdb-query "SELECT AVG(val) as mean FROM scratch"))
+;; => (((mean . 0.33628298988435995)))
+#+end_src
+
+Sessions provide 7-10x speedup for simple queries:
+
+| Executor | Simple Query | 10k Rows |
+|----------+--------------+----------|
+| :cli     | ~22ms        | ~93ms    |
+| :session | ~2ms         | ~20ms    |
+
+** Attaching External Databases
+
+Attach external database files to a session for cross-database queries.
+~duckdb-query-with-database~ works seamlessly inside session scope:
+
+#+begin_src elisp :results code
+(duckdb-query-session-start "analysis")
+(unwind-protect
+    (duckdb-query-with-session "analysis"
+      ;; Create local session table
+      (duckdb-query "CREATE TABLE local_summary AS SELECT 'session' as src")
+
+      ;; Attach external database - automatically becomes default catalog
+      (duckdb-query-with-database '("/data/sales.db" :readonly t)
+        ;; Unqualified names resolve to attached database
+        (duckdb-query "SELECT * FROM orders LIMIT 5")))
+  (duckdb-query-session-kill "analysis"))
+#+end_src
+
+The macro handles catalog context automatically:
+- ATTACHes the database with specified readonly mode
+- Executes ~USE alias.main~ to make it the default catalog
+- Restores previous catalog context after the block
+- DETACHes the database on exit
+
+For manual control, use ~duckdb-query-session-attach~ and ~duckdb-query-session-detach~:
+
+#+begin_src elisp :results code
+(duckdb-query-session-start "work")
+(unwind-protect
+    (duckdb-query-with-session "work"
+      (let ((alias (duckdb-query-session-attach "work" "/data/sales.db" nil t)))
+        ;; Access with qualified names: alias.table_name
+        (duckdb-query (format "SELECT COUNT(*) FROM %s.orders" alias))
+        (duckdb-query-session-detach "work" alias)))
+  (duckdb-query-session-kill "work"))
+#+end_src
+
+** Transient Databases in Session Scope
+
+~duckdb-query-with-transient-database~ also adapts to session context:
+
+#+begin_src elisp :results code
+(duckdb-query-with-transient-session "work"
+  (duckdb-query "CREATE TABLE permanent AS SELECT 'stays' as val")
+
+  (duckdb-query-with-transient-database
+    ;; Temp database attached and set as default catalog
+    (duckdb-query "CREATE TABLE scratch AS SELECT 'gone' as val")
+    (duckdb-query-value "SELECT val FROM scratch"))
+  ;; => "gone"
+
+  ;; Back to session context, scratch is gone
+  (duckdb-query-value "SELECT val FROM permanent"))
+;; => "stays"
+#+end_src
+
+** Session Management
+
+List active sessions:
+#+begin_src elisp :results code
+(duckdb-query-session-list)
+;; => (#s(duckdb-session :name "analytics" :status active :query-count 42 ...))
+#+end_src
+
+Interactive commands:
+- ~M-x duckdb-query-session-display-status~ - Show all sessions with statistics
+- ~M-x duckdb-query-session-kill-interactive~ - Kill session with completion
+- ~M-x duckdb-query-session-kill-all~ - Kill all sessions
+
+Session initialization commands run when sessions start:
+#+begin_src elisp :results code
+(setq duckdb-query-session-init-commands
+      '("SET memory_limit = '4GB'"
+        "INSTALL spatial"
+        "LOAD spatial"))
+#+end_src
+* Nested Types
+:PROPERTIES:
+:CUSTOM_ID: nested-types
+:END:
+
+DuckDB supports STRUCT, LIST, MAP, and ARRAY types. The default file-based
+output mode serializes these correctly as nested Elisp structures:
+
+#+begin_src elisp :results code
+(duckdb-query
+ "SELECT
+    {'x': 1, 'y': 2}::STRUCT(x INT, y INT)
+    as point")
+;; => (((point (x . 1) (y . 2))))
+#+end_src
+
+#+begin_src elisp :results code
+;; Arrays become Elisp lists
+(duckdb-query
+ "SELECT [1, 2, 3] as nums,
+         ['a', 'b'] as letters")
+;; => (((nums 1 2 3) (letters "a" "b")))
+#+end_src
+
+#+begin_src elisp :results code
+;; Nested structs
+(duckdb-query
+ "SELECT
+    {'person':
+      {'name': 'Alice', 'age': 30},
+     'active': true}
+    as record")
+;; => (((record (person (name . "Alice") (age . 30)) (active . t))))
+#+end_src
+
+#+begin_src elisp :results code
+;; Nested data survives roundtrips
+(let ((data
+       '(((id . 1) (loc (x . 10) (y . 20)))
+         ((id . 2) (loc (x . 30) (y . 40))))))
+  (duckdb-query
+   "SELECT id, loc.x + loc.y as sum
+    FROM @data"
+   :data data))
+;; => (((id . 1) (sum . 30)) ((id . 2) (sum . 70)))
+#+end_src
+
+** Pipe Mode and =:preserve-nested=
+
+When using =:output-via :pipe= (streaming mode) or session execution for DDL
+fallback, nested types serialize as DuckDB's string representation instead of
+proper JSON. The =:preserve-nested= parameter wraps nested columns with
+=to_json()= to restore correct serialization:
+
+#+begin_src elisp :results code
+;; Without :preserve-nested in pipe mode
+(duckdb-query "SELECT {'x': 1}::STRUCT(x INT) as s"
+              :output-via :pipe)
+;; => (((s . "{'x': 1}")))  ; String representation
+
+;; With :preserve-nested
+(duckdb-query "SELECT {'x': 1}::STRUCT(x INT) as s"
+              :output-via :pipe
+              :preserve-nested t)
+;; => (((s (x . 1))))  ; Proper nested structure
+#+end_src
+
+The default =:output-via :file= mode handles nested types correctly without
+=:preserve-nested=. Use =:preserve-nested= when:
+- Explicitly requesting =:output-via :pipe=
+- Inside session scope where DDL statements force pipe fallback
+- Roundtripping nested data through =@data:= bindings after pipe-mode queries
+
+* Performance
+:PROPERTIES:
+:CUSTOM_ID: performance
+:END:
+
+The package writes results to temporary files by default, providing 3-5x speedup
+on large results compared to streaming through stdout:
+
+: | Result Size | Default (file) | Streaming (pipe) | Speedup |
+: |-------------+----------------+------------------+---------|
+: | 10k rows    | 64ms           | 162ms            | 2.5x    |
+: | 100k rows   | 366ms          | 1.28s            | 3.5x    |
+: | 500k rows   | 1.32s          | 6.19s            | 4.7x    |
+
+Force streaming mode with ~:output-via :pipe~ when needed. DDL statements
+automatically use streaming since they cannot be wrapped in file output.
+
+Profile your specific queries with the benchmark module:
+
+#+begin_src elisp :results code
+(require 'duckdb-query-bench)
+(duckdb-query-bench-output-strategies
+ "SELECT * FROM range(10000) t(i)"
+ :iterations 3)
+#+end_src
+
+#+RESULTS:
+#+begin_src elisp
+((strategy mean min max n) (:file "20.47ms" "19.55ms" "22.13ms" 3)
+ (:pipe "31.77ms" "30.21ms" "33.47ms" 3) (:speedup "1.55x" "" "" ""))
+#+end_src
+
+
+Other benchmark functions: ~duckdb-query-bench-formats~ (compare output formats),
+~duckdb-query-bench-nested-types~ (compare nested type handling),
+~duckdb-query-bench-data-formats~ (compare ~:data~ serialization).
+
+#+begin_quote
+[!NOTE]
+I'm in the process of adding more benchmark utilities geared towards measuring performance for parameterized queries.
+#+end_quote
+
+* Font Lock for Reference Syntax
+:PROPERTIES:
+:CUSTOM_ID: font-lock-for-reference-syntax
+:END:
+
+The =duckdb-query-font-lock-mode= minor mode highlights =@type:name= references
+inside SQL strings passed to =duckdb-query=, =duckdb-query-value=,
+=duckdb-query-row=, and =duckdb-query-column=.
+
+References are highlighted only within recognized function calls, not in
+docstrings, comments, or other string contexts. When added to
+=emacs-lisp-mode-hook=, the mode also activates in org-mode src blocks with
+lightweight overhead (keywords only, no preset application or region extension
+hooks).
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-font-lock-enabled.png?raw=true" align="center" width="100%">
+
+Invalid references are highlighted with a warning face. This'll apply to names
+not found in the corresponding =:sql=, =:data=, or =:val= parameter, and also to
+references which are not compatible inside one another (for more info, see [[#reference-type-summary][Reference Type Summary]]).
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-font-lock-warning-enabled.png?raw=true" align="center" width="100%">
+
+** Preset Selection
+
+Nine highlighting presets are available. Select interactively with live preview:
+
+#+begin_src
+M-x duckdb-query-font-lock-select-preset
+#+end_src
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-query-1_2180x2220.gif?raw=true" align="center" width="100%">
+Or set directly:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-font-lock-preset 'shadow-bold-constant)  ; default
+;; Other presets: shadow-bold-variable, keyword-variable, uniform-type,
+;; uniform-keyword, italic-shadow-bold-constant, light-extra-bold,
+;; shadow-completions, italic-shadow-bold-underline
+#+end_src
+
+** Custom Faces
+
+For fine-grained control, customize the faces directly:
+
+- ~duckdb-query-reference-prefix-face~: The =@type:= portion
+- ~duckdb-query-reference-name-face~: The =name= portion
+- ~duckdb-query-reference-invalid-face~: Undefined or invalid references
+
+#+begin_src emacs-lisp
+(set-face-attribute 'duckdb-query-reference-prefix-face nil
+                    :inherit 'shadow :slant 'italic)
+(set-face-attribute 'duckdb-query-reference-name-face nil
+                    :inherit 'font-lock-constant-face :weight 'bold)
+#+end_src
+
+* SQL Completion
+:PROPERTIES:
+:CUSTOM_ID: sql-completion
+:END:
+
+The =duckdb-query-complete-mode= minor mode provides completion-at-point inside
+SQL string arguments to =duckdb-query= and related functions. It works with
+corfu, company-mode, and the default completion UI.
+
+Three completion contexts activate depending on cursor position within a SQL
+string:
+
+- Reference Completion ::
+
+Typing =@= triggers reference type completion, offering =sql:=, =data:=, =val:=,
+and =org:= as candidates with descriptions. After selecting a type (or typing it
+manually), the completion system reads binding names from the corresponding
+parameter in the same =duckdb-query= form.
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-complete-example_2000x1800.gif?raw=true" align="center" width="100%">
+
+Reference completion is exclusive: when active, other completion sources do not
+contribute conflicting candidates.
+
+- SQL Keyword, Function, and Type Completion ::
+
+Outside of =@type:= contexts, the mode completes SQL keywords, functions, and
+data types from cached DuckDB metadata. The cache populates once at mode enable
+by querying =duckdb_keywords()=, =duckdb_functions()=, and =duckdb_types()=,
+providing approximately 3400 candidates with zero per-keystroke latency.
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-sql-completion_2000x1800.gif?raw=true" align="center" width="100%">
+
+Both uppercase and lowercase variants are generated for SQL keywords, so
+completion works regardless of typing case.
+
+Candidates are annotated with category labels:
+
+| Label   | Meaning                  |
+|---------+--------------------------|
+| =kw*=     | Reserved SQL keyword     |
+| =kw=      | Unreserved SQL keyword   |
+| =fn=      | Scalar function          |
+| =fn/a=    | Aggregate function       |
+| =fn/m=    | SQL macro                |
+| =fn->T=   | Table-producing function |
+| =fn/m->T= | Table-producing macro    |
+| =pragma=  | Pragma function          |
+| =type=    | Data type                |
+
+Reserved keywords sort before other candidates.
+
+After loading extensions or attaching databases that add new functions or types:
+
+#+begin_src
+M-x duckdb-query-complete-refresh-cache
+#+end_src
+
+To disable SQL metadata completion entirely and keep only reference completion:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-complete-sql-p nil)
+#+end_src
+
+** Static Analysis Candidates
+
+The completion system also extracts candidates from the SQL string being edited,
+without querying DuckDB:
+
+- CTE names from =WITH name AS= patterns
+- Table aliases from =FROM table alias= and =JOIN table alias= patterns
+- =@data:= binding names as table-like candidates
+
+These candidates sort above DuckDB metadata, so query-specific identifiers
+appear first. They carry their own category labels (=cte=, =alias=, =data=) for
+identification.
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-cte-completion_1920x1080.gif?raw=true" align="center" width="100%">
+
+* Acknowledgements
+
+Several packages and tools served as reference points for the design and
+implementation of duckdb-query. I would like to credit:
+
+- [[https://github.com/ak-coram/cl-duckdb][cl-duckdb]] by Ákos Kiss: The Common Lisp DuckDB wrapper that inspired treating
+  query results as native Lisp data structures. The =with-static-table= pattern
+  for querying Lisp data directly and the =with-transient-connection= /
+  =with-default-connection= macros for database context management informed the
+  design of =:data=, =@org:= references, =duckdb-query-with-transient-database=, and
+  =duckdb-query-with-database=.
+
+- [[https://github.com/marijnh/Postmodern][Postmodern]] by Marijn Haverbeke: Common Lisp library for PostgreSQL
+  interaction. The database context macros and the =:row=, =:column=, and =:single=
+  output formats introduced in version 0.8 were taken directly from Postmodern's
+  design.
+
+- [[https://github.com/distichum/datagrid][datagrid]] by Joshua Lambert: Emacs package for data manipulation. The decision
+  to add the =:columnar= output format was partly inspired by this package.
+
+- [[https://github.com/tconbeer/harlequin][Harlequin]] by Ted Conbeer: The SQL autocompletion cache and its use of DuckDB
+  meta-functions (=duckdb_functions=, =duckdb_tables=, =duckdb_keywords=,
+  =duckdb_types=) for context-aware completion were inspired by Harlequin's
+  approach.
+
+- Font-lock implementation drew from several packages by Fanael Linithien:
+  [[https://github.com/Fanael/highlight-defined][highlight-defined]], [[https://github.com/Fanael/highlight-numbers][highlight-numbers]], and especially [[https://github.com/Fanael/rainbow-delimiters][rainbow-delimiters]].
+
+- [[https://github.com/abo-abo/lispy][lispy]] by Oleh Krehel: The parser's use of [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Position-Parse.html#index-syntax_002dppss][syntax-ppss]] for structural analysis
+  of Elisp forms was learned from studying lispy's implementation.
+
+- 
+
+* Related Packages
+:PROPERTIES:
+:CUSTOM_ID: related-packages
+:END:
+
+- [[https://github.com/jhinch/ob-duckdb][ob-duckdb]]: Org Babel integration for DuckDB source blocks. SOON I'll add most
+  of the functionalities here to it via a specialized ob-duckdb-query executor,
+  this will allow org-table reference in duckdb-sql source blocks and new output
+  types.
+* Integration
+:PROPERTIES:
+:CUSTOM_ID: integration
+:END:
+
+#+begin_quote
+[!NOTE]
+The patterns below are stable APIs, but the abstractions built on them are still evolving.
+#+end_quote
+
+As mentioned before, sessions allow low-latency, fast response times, going as
+low as 2ms on frequent, repeating small queries like batched updates/inserts and
+single row extraction. Add to this persistent session processes that can
+communicate between each other via database ~ATTACH~/~DETACH~ or external file
+output/input, and we have the *foundation for database-backed major modes, worker
+pools, and orchestrated data pipelines within Emacs.*
+
+
+** Buffer-Local Sessions
+
+The ~duckdb-query-session-setup-buffer~ helper attaches a session to the current
+buffer. It creates the session if needed, registers the buffer as an owner, and
+sets up the buffer-local binding so all ~duckdb-query~ calls within that buffer
+automatically route to the session. The session persists while any owning buffer
+exists and is killed when the last owner closes:
+
+#+begin_src elisp :results code
+(add-hook 'my-data-mode-hook
+          (lambda ()
+            (duckdb-query-session-setup-buffer "my-data-session")))
+;; All my-data-mode buffers share one session
+;; Session killed when last my-data-mode buffer closes
+#+end_src
+
+This pattern enables major modes that maintain persistent analytical state. A
+dashboard mode might cache expensive aggregations in session tables and refresh
+instantly on demand:
+
+#+begin_src elisp :results code
+(define-derived-mode my-dashboard-mode special-mode "Dashboard"
+  (duckdb-query-session-setup-buffer "dashboard")
+  (setq-local revert-buffer-function #'my-dashboard-refresh))
+
+(defun my-dashboard-refresh (&rest _)
+  "Refresh dashboard from session's cached aggregations."
+ (let ((data (duckdb-query "SELECT * FROM cached_metrics")))
+    (my-dashboard-render data)))
+#+end_src
+
+** Lifecycle Hooks
+
+Three hooks provide visibility into session activity, enabling logging, metrics
+collection, and cross-session coordination:
+
+#+begin_src elisp :results code
+;; Log all queries with timing
+(add-hook 'duckdb-query-session-query-executed-functions
+          (lambda (name query duration-ms)
+            (message "[%s] %.1fms: %s"
+                     name duration-ms
+                     (truncate-string-to-width query 60))))
+
+;; Track session lifecycle
+(add-hook 'duckdb-query-session-created-functions
+          (lambda (name _session)
+            (message "Session started: %s" name)))
+
+(add-hook 'duckdb-query-session-killed-functions
+          (lambda (name)
+            (message "Session ended: %s" name)))
+#+end_src
+
+These hooks will be essential for building a coordinator layer that manages
+worker sessions, tracks query performance across the system, and handles
+failover when sessions die unexpectedly.
+
+** Future Directions
+
+This infrastructure opens up architectural patterns that go beyond single-query
+workflows. The ultimate goal is to enable the creation of data-centric emacs
+packages and tools, such as:
+
+- quickly retrieving tabular data from most filetypes or complex queries
+- perform tens to hundreds of CRUD operations per second
+- manage and orchestrate data processing jobs across multiple workers from a central coordinator
+- leverage [[https://github.com/cwida/duckpgq-extension][graph queries]], [[https://github.com/duckdb/duckdb-spatial][geo-spatial processing]], [[https://github.com/duckdb/duckdb-vss][vector similarity search]] and other techniques inside Emacs
+
+Some directions still in design:
+
+- *Database-backed buffers*: Major modes where buffer content is backed by
+  session tables, enabling SQL-powered search, filter, and transform operations
+  that would be impractical with pure Elisp
+- *Worker pools*: Multiple sessions processing jobs in parallel, coordinated
+  through a shared database via ~ATTACH~ or message-passing through elisp.
+- *Live dashboards*: Buffers that subscribe to query results and refresh
+  automatically when underlying data changes
+
+I'll update this section as these experiments mature into usable packages.

--- a/README-EMACS.org
+++ b/README-EMACS.org
@@ -625,6 +625,16 @@ substitution happens before =:val= processing:
 #+begin_quote
 [!IMPORTANT]
 Variables are /scalar/ values. They must resolve to exactly one column and one
+row, single value variables are also valid, for example a single url string or a
+number.
+
+Subqueries returning multiple columns or rows will error: =Binder Error:
+Subquery returns 2 columns - expected 1=. For table-valued data, use =@data:=
+bindings instead.
+#+end_quote
+
+[!IMPORTANT]
+Variables are /scalar/ values. They must resolve to exactly one column and one
 row. Subqueries returning multiple columns or rows will error:
 =Binder Error: Subquery returns 2 columns - expected 1=.
 For table-valued data, use =@data:= bindings instead.
@@ -1354,7 +1364,7 @@ implementation of duckdb-query. I would like to credit:
 - [[https://github.com/abo-abo/lispy][lispy]] by Oleh Krehel: The parser's use of [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Position-Parse.html#index-syntax_002dppss][syntax-ppss]] for structural analysis
   of Elisp forms was learned from studying lispy's implementation.
 
-- 
+-
 
 * Related Packages
 :PROPERTIES:

--- a/README-EMACS.org
+++ b/README-EMACS.org
@@ -144,12 +144,14 @@ dependencies, and fragment composition with embedded references, see
 - [[#parameterized-queries][Parameterized Queries]]
 - [[#output-formats][Output Formats]]
 - [[#schema-introspection][Schema Introspection]]
+- [[#type-parsing][Type Parsing]]
 - [[#database-persistence][Database Persistence]]
 - [[#session-based-execution][Session-Based Execution]]
 - [[#nested-types][Nested Types]]
 - [[#performance][Performance]]
 - [[#font-lock-for-reference-syntax][Font Lock for Reference Syntax]]
 - [[#sql-completion][SQL Completion]]
+- [[#structural-editing][Structural Editing]]
 - [[#acknowledgements][Acknowledgements]]
 - [[#related-packages][Related Packages]]
 - [[#integration][Integration]]
@@ -886,6 +888,106 @@ Discover structure before querying:
 ;;     ((column_name . "name") (column_type . "VARCHAR") (null . "YES") ...))
 #+end_src
 
+~duckdb-query-column-types~ accepts a ~:format~ parameter for structured output.
+See [[#type-parsing][Type Parsing]] for parsed and JSON formats.
+* Type Parsing
+:PROPERTIES:
+:CUSTOM_ID: type-parsing
+:END:
+#+begin_quote
+[!IMPORTANT]
+NEW in 0.8
+#+end_quote
+
+DuckDB's =DESCRIBE= output returns type information as strings. For scalar types
+like ="INTEGER"= this is sufficient, but complex nested types from extensions
+like =webbed= (XML reader) or =spatial= produce opaque strings hundreds of
+characters long. The type parser converts these into structured Elisp:
+
+#+begin_src elisp :results code
+(duckdb-query-parse-type "STRUCT(x INTEGER, y VARCHAR)")
+;; => (STRUCT (x . INTEGER) (y . VARCHAR))
+#+end_src
+
+#+begin_src elisp :results code
+(duckdb-query-parse-type "MAP(VARCHAR, INTEGER[])")
+;; => (MAP VARCHAR (LIST INTEGER))
+#+end_src
+
+#+begin_src elisp :results code
+(duckdb-query-parse-type "STRUCT(a STRUCT(b INTEGER, tags VARCHAR[]))")
+;; => (STRUCT (a . (STRUCT (b . INTEGER) (tags . (LIST VARCHAR)))))
+#+end_src
+
+The parser handles the full DuckDB type system: STRUCT, MAP, LIST, ARRAY, UNION,
+parameterized scalars like =DECIMAL(18,3)=, double-quoted field names, extension
+types, and user-defined types. The representation uses symbols for scalar types
+and nested lists for compound types, making it natural for ~pcase~, ~assq~, and
+recursive traversal.
+
+The ~duckdb-query-column-types~ function accepts a ~:format~ parameter to control
+type representation across an entire schema:
+
+#+begin_src elisp :results code
+;; Raw strings (default, backward compatible)
+(duckdb-query-column-types
+ "SELECT 1 AS id, {'x': 1, 'y': 2}::STRUCT(x INT, y INT) AS point")
+;; => (("id" . "INTEGER") ("point" . "STRUCT(x INTEGER, y INTEGER)"))
+#+end_src
+
+#+begin_src elisp :results code
+;; Parsed Elisp structures
+(duckdb-query-column-types
+ "SELECT 1 AS id, {'x': 1, 'y': 2}::STRUCT(x INT, y INT) AS point"
+ :format :parsed)
+;; => (("id" . INTEGER) ("point" . (STRUCT (x . INTEGER) (y . INTEGER))))
+#+end_src
+
+#+begin_src elisp :results code
+;; JSON schema string
+(duckdb-query-column-types
+ "SELECT 1 AS id, [1,2,3] AS arr"
+ :format :json)
+;; => "[{\"name\":\"id\",\"type\":\"INTEGER\"},{\"name\":\"arr\",\"type\":{\"type\":\"LIST\",\"element\":\"INTEGER\"}}]"
+#+end_src
+
+Individual parsed types can be converted to JSON-serializable structures with
+~duckdb-query-type-to-json~ for integration with external tools or APIs.
+
+The parsed representation enables programmatic schema exploration. For example,
+extracting all field names from a deeply nested STRUCT:
+
+#+begin_src elisp :results code
+(defun my-struct-fields (parsed)
+  "Recursively collect field names from PARSED type."
+  (when (and (listp parsed) (eq (car parsed) 'STRUCT))
+    (let ((fields (cdr parsed)))
+      (append (mapcar (lambda (f) (symbol-name (car f))) fields)
+              (cl-mapcan (lambda (f) (my-struct-fields (cdr f)))
+                         fields)))))
+
+(my-struct-fields
+ (duckdb-query-parse-type
+  "STRUCT(name VARCHAR, address STRUCT(city VARCHAR, zip INTEGER))"))
+;; => ("name" "address" "city" "zip")
+#+end_src
+
+Or pattern matching on column types:
+
+#+begin_src elisp :results code
+(let ((types (duckdb-query-column-types
+              "SELECT 1 AS id, [1,2] AS nums, {'x': 1} AS pt"
+              :format :parsed)))
+  (mapcar (lambda (col)
+            (cons (car col)
+                  (pcase (cdr col)
+                    (`(STRUCT . ,_) "struct")
+                    (`(LIST ,_) "list")
+                    (`(MAP ,_ ,_) "map")
+                    ((pred symbolp) "scalar"))))
+          types))
+;; => (("id" . "scalar") ("nums" . "list") ("pt" . "struct"))
+#+end_src
 * Database Persistence
 :PROPERTIES:
 :CUSTOM_ID: database-persistence
@@ -1333,7 +1435,144 @@ identification.
 
 #+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-cte-completion_1920x1080.gif?raw=true" align="center" width="100%">
 
+* Structural Editing
+:PROPERTIES:
+:CUSTOM_ID: structural-editing
+:END:
+#+begin_quote
+[!IMPORTANT]
+NEW in 0.8: Extract, inline, and remove =@type:name= references structurally
+#+end_quote
+
+The =duckdb-query-edit.el= module provides bidirectional structural editing for
+=duckdb-query= forms. As queries grow complex, you progressively decompose
+monolithic SQL strings into composable fragments bound to =:val=, =:sql=, and
+=:data= parameters. The reverse operation supports simplification when references
+are no longer needed.
+
+All commands operate on the enclosing =duckdb-query= form detected via the
+structural parser. No configuration is required beyond loading the module.
+** Extracting to References
+# TODO: add videos to this
+
+Select a region inside a SQL string, then extract it into a named reference with
+the corresponding binding:
+
+#+begin_src elisp
+;; Starting form:
+(duckdb-query
+ "SELECT * FROM read_parquet('https://example.com/data.parquet')
+  WHERE month BETWEEN 6 AND 8")
+
+;; Select the URL, invoke M-x duckdb-query-edit-extract-to-val,
+;; name it "url":
+(duckdb-query
+ "SELECT * FROM read_parquet(@val:url)
+  WHERE month BETWEEN 6 AND 8"
+ :val '((url . "https://example.com/data.parquet")))
+
+;; Then select "month BETWEEN 6 AND 8",
+;; invoke M-x duckdb-query-edit-extract-to-sql, name it "filter":
+(duckdb-query
+ "SELECT * FROM read_parquet(@val:url)
+  WHERE @sql:filter"
+ :val '((url . "https://example.com/data.parquet"))
+ :sql '((filter . "month BETWEEN 6 AND 8")))
+#+end_src
+
+Three pre-typed convenience commands skip the type prompt:
+
+- ~duckdb-query-edit-extract-to-val~: Extract to =:val= parameter
+- ~duckdb-query-edit-extract-to-sql~: Extract to =:sql= parameter
+- ~duckdb-query-edit-extract-to-data~: Extract to =:data= parameter
+
+The general command ~duckdb-query-edit-extract-to-ref~ prompts for both reference
+type and name.
+
+Extraction works inside any string literal in the form, not just the main SQL
+string. This enables progressive decomposition where a fragment extracted from
+the main query can itself be further decomposed from its =:sql= binding value.
+
+** Inlining References
+
+Place point on any =@type:name= reference and invoke
+~duckdb-query-edit-inline-ref~ to replace it with the binding's literal value:
+
+#+begin_src elisp
+;; Point on @sql:filter, invoke M-x duckdb-query-edit-inline-ref:
+;; Before:
+(duckdb-query "SELECT * FROM t WHERE @sql:filter"
+              :sql '((filter . "age > 21")))
+
+;; After (binding preserved):
+(duckdb-query "SELECT * FROM t WHERE age > 21"
+              :sql '((filter . "age > 21")))
+
+;; With C-u prefix, binding is also removed:
+(duckdb-query "SELECT * FROM t WHERE age > 21")
+#+end_src
+
+Without prefix argument, the binding entry is preserved in the parameter alist.
+Orphaned bindings are visible via ~duckdb-query-font-lock-mode~, which highlights
+undefined references. With =C-u= prefix, the binding entry is also removed,
+completing the full round-trip.
+** Removing Bindings
+
+~duckdb-query-edit-remove-binding~ removes the binding entry for the reference at
+point without modifying the reference text. When other references to the same
+binding exist in the form, it prompts for confirmation showing the reference
+count:
+
+#+begin_src elisp
+;; Point on @val:threshold (used twice in the query):
+;; M-x duckdb-query-edit-remove-binding
+;; => "@val:threshold has 2 references; remove binding anyway?"
+#+end_src
+
+~duckdb-query-edit-remove-unused-bindings~ performs bulk cleanup, scanning all
+bindings in the enclosing form and removing those with zero references.
+
+** Value Formatting
+
+Extracted text is formatted appropriately for the target parameter type:
+
+| Target | Input (selected text) | Stored binding value     |
+|--------+-----------------------+--------------------------|
+| =:val=   | ='./data/users.csv'=    | ="./data/users.csv"=       |
+| =:val=   | =42=                    | =42= (numeric, not quoted) |
+| =:sql=   | =month BETWEEN 6 AND 8= | ="month BETWEEN 6 AND 8"=  |
+| =:data=  | (as-is)               | (for manual editing)     |
+
+For =:val=, surrounding SQL single-quotes are stripped because
+~duckdb-query--value-to-sql-literal~ re-adds them at execution time. Numeric
+strings pass through without quoting.
+** Indentation
+
+Post-edit indentation is controlled by ~duckdb-query-edit-indent-after-edit~,
+which defaults to =nil=. When non-nil, ~indent-region~ runs on the enclosing
+=duckdb-query= form after every structural modification. The default respects
+users who rely on ~aggressive-indent-mode~ or other formatting tools:
+
+#+begin_src elisp
+(setq duckdb-query-edit-indent-after-edit t)
+#+end_src
+
+** Command Summary
+
+| Command                                  | Trigger            | Behavior                             |
+|------------------------------------------+--------------------+--------------------------------------|
+| ~duckdb-query-edit-extract-to-ref~         | Region in string   | Prompt type and name, create binding |
+| ~duckdb-query-edit-extract-to-val~         | Region in string   | Create =:val= binding                  |
+| ~duckdb-query-edit-extract-to-sql~         | Region in string   | Create =:sql= binding                  |
+| ~duckdb-query-edit-extract-to-data~        | Region in string   | Create =:data= binding                 |
+| ~duckdb-query-edit-inline-ref~             | Point on reference | Replace ref with value text          |
+| =C-u= ~duckdb-query-edit-inline-ref~         | Point on reference | Replace ref and remove binding       |
+| ~duckdb-query-edit-remove-binding~         | Point on reference | Remove binding, keep reference       |
+| ~duckdb-query-edit-remove-unused-bindings~ | Anywhere in form   | Remove all zero-reference bindings   |
 * Acknowledgements
+:PROPERTIES:
+:CUSTOM_ID: acknowledgements
+:END:
 
 Several packages and tools served as reference points for the design and
 implementation of duckdb-query. I would like to credit:

--- a/README.org
+++ b/README.org
@@ -1,514 +1,138 @@
 #+title: duckdb-query.el - Query Anything, Get Elisp
 #+options: toc:nil
 
+#+begin_quote
+[!IMPORTANT]
+Now on MELPA
+#+end_quote
+
 Query remote Parquet files, local CSVs, org-mode tables, and Elisp data
 structures with SQL. Get results as native Elisp values. One function call, no
 intermediate files, no external scripts.
 
-#+begin_html
-<table align="center"><tr>
-    <th width="700px">Query Remote Data, Filter with Elisp, Get Native Structures</th></tr>
-<tr><td>
+#+HTML:<p align="center"><em>Join 336k-row remote Parquet with Elisp alist, parameterized with native SQL variables</em></p>
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-full-example.png?raw=true" align="center" width="100%">
 
-<p><strong>Query joining 336k-row remote Parquet with Elisp alist:</strong></p>
-<pre lang="elisp">(let ((carriers '(((code . "UA") (name . "United Airlines"))
+#+begin_html
+<details><summary>
+<strong>code for this example</strong></summary>
+
+<pre lang="elisp">
+(let ((carriers '(((code . "UA") (name . "United Airlines"))
                   ((code . "AA") (name . "American Airlines"))
                   ((code . "DL") (name . "Delta Air Lines")))))
   (duckdb-query
-   "SELECT c.name as airline,
-           {'flights': COUNT(*),
-            'avg_delay': ROUND(AVG(f.arr_delay), 1)} as stats
-    FROM 'https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet' f
-    JOIN @carriers c ON f.carrier = c.code
+   "SELECT c.name AS airline,
+           COUNT(*) AS flights,
+           ROUND(AVG(f.arr_delay), 1) AS avg_delay
+    FROM read_parquet(@val:url) f
+    JOIN @data:carriers c ON f.carrier = c.code
+    WHERE f.month BETWEEN @val:from_month AND @val:to_month
     GROUP BY c.name
-    ORDER BY COUNT(*) DESC"
+    ORDER BY flights DESC"
    :data `((carriers . ,carriers))
-   :format :columnar))</pre>
+   :val '((url . "https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet")
+          (from_month . 6) (to_month . 8))
+   :format :columnar))
 
-<p><strong>Result (columnar format with nested structs):</strong></p>
-<pre lang="elisp">((airline . ["United Airlines" "Delta Air Lines" "American Airlines"])
- (stats . [((flights . 58665) (avg_delay . 3.6))
-           ((flights . 48110) (avg_delay . 1.6))
-           ((flights . 32729) (avg_delay . 0.4))]))</pre>
-</td></tr></table>
-<p align="center"><em>One function call: remote Parquet + Elisp filter → nested Elisp structures</em></p>
+;; => ((airline . ["United Airlines" "Delta Air Lines" "American Airlines"])
+;;     (flights . [15165 12695 8495])
+;;     (avg_delay . [8.9 9.6 2.8]))
+</pre>
+</details>
 #+end_html
 
 DuckDB is an embedded analytical database that reads Parquet, CSV, and JSON
 directly from local paths, HTTP URLs, or cloud storage. This package makes
 DuckDB's capabilities available to Elisp programs. The ~duckdb-query~ function
 executes SQL and returns alists, plists, vectors, or org-table-compatible lists.
-Results are ready for ~mapcar~, ~seq-filter~, ~cl-loop~, or direct insertion
-into buffers.
+Results are ready for ~mapcar~, ~seq-filter~, ~cl-loop~, or direct insertion into
+buffers.
 
 The package treats all data sources uniformly. Elisp alists become SQL tables
 via the ~:data~ parameter. Named org tables in your buffer resolve through
-~@org:table-name~ syntax. These combine freely with file paths and URLs in
-joins, unions, and subqueries. A query can join a remote Parquet file with a
-ten-row org table and a runtime Elisp variable, returning the result as an
-alist you can immediately process.
-
-* COMMENT README
-# ================
-
-=This commented out treee is for usage inside of emacs=
-=without all the html getting in the way=
-
-# ================
-
-#+begin_src elisp :results code
-(let ((carriers '(((code . "UA") (name . "United Airlines"))
-                  ((code . "AA") (name . "American Airlines"))
-                  ((code . "DL") (name . "Delta Air Lines")))))
-  (duckdb-query
-   "SELECT c.name as airline,
-           {'flights': COUNT(*),
-            'avg_delay': ROUND(AVG(f.arr_delay), 1)} as stats
-    FROM 'https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet' f
-    JOIN @carriers c ON f.carrier = c.code
-    GROUP BY c.name
-    ORDER BY COUNT(*) DESC"
-   :data `((carriers . ,carriers))
-   :format :columnar))
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-((airline . ["United Airlines" "Delta Air Lines" "American Airlines"])
- (stats
-  . [((flights . 58665) (avg_delay . 3.6)) ((flights . 48110) (avg_delay . 1.6))
-     ((flights . 32729) (avg_delay . 0.4))]))
-#+end_src
-
-** COMMENT Quick Examples
-
-#+begin_src elisp :results code
-(duckdb-query
- "SELECT 'Alice' as name, 95 as score
-  UNION ALL SELECT 'Bob', 87")
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-(((name . "Alice") (score . 95)) ((name . "Bob") (score . 87)))
-#+end_src
-
-#+begin_src elisp :results code
-(duckdb-query
- "SELECT * FROM range(1,4) t(n),
-   (SELECT unnest(['a','b']) as letter)"
- :format :org-table)
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-((n letter) (1 "a") (2 "a") (3 "a") (1 "b") (2 "b") (3 "b"))
-#+end_src
-
-#+begin_src elisp :results code
-(duckdb-query-value
- "SELECT COUNT(*) FROM range(1000)")
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-1000
-#+end_src
-
-#+begin_src elisp :results code
-(duckdb-query-column "SELECT unnest(['red','green','blue']) as color")
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-("red" "green" "blue")
-#+end_src
-
-#+begin_src elisp :results code
-(duckdb-query
- "SELECT * FROM range(5) t(n)"
- :format :columnar)
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-((n . [0 1 2 3 4]))
-#+end_src
-
-** COMMENT Querying Elisp Data
-
-Pass Elisp alists to queries via the ~:data~ parameter. The data becomes a table
-named ~@data~:
-
-#+begin_src elisp :results code
-(duckdb-query
- "SELECT name, score * 1.1 as curved
-  FROM @data
-  WHERE score > 85"
- :data '(((name . "Aly") (score . 95))
-         ((name . "Bob") (score . 87))
-         ((name . "Carol") (score . 72))))
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-(((name . "Aly") (curved . 104.5)) ((name . "Bob") (curved . 95.7)))
-#+end_src
-
-For multiple tables, use named bindings with backquote to capture lexical
-variables:
-
-#+begin_src elisp :results code
-(let ((users ;; users table
-       '(((id . 1) (name . "Alice"))
-         ((id . 2) (name . "Bob"))))
-      (orders ;; orders table
-       '(((user_id . 1) (item . "Widget"))
-         ((user_id . 2) (item . "Gadget"))
-         ((user_id . 1) (item . "Gizmo")))))
-  (duckdb-query
-   "SELECT u.name, COUNT(*) as count
-    FROM @users u
-    JOIN @orders o ON u.id = o.user_id
-    GROUP BY u.name"
-   :data `((users . ,users)
-           (orders . ,orders))))
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-(((name . "Alice") (count . 2)) ((name . "Bob") (count . 1)))
-#+end_src
-
-This enables joining runtime Elisp state with static file data. Previously this
-required exporting to CSV, running an external query, and parsing results. Now
-it is one expression.
-
-** COMMENT Querying Org Tables
-
-Reference named org tables with ~@org:table-name~. Given this table in your
-buffer:
-
-#+NAME: inventory
-| sku   | product | stock | price |
-|-------+---------+-------+-------|
-| A-100 | Widget  |    50 |  9.99 |
-| B-200 | Gadget  |    30 | 24.99 |
-| C-300 | Gizmo   |    75 | 14.99 |
-
-#+begin_src elisp :results code
-(duckdb-query
- "SELECT product,
-    stock * price as value
-  FROM @org:inventory
-  ORDER BY value DESC"
- :format :org-table)
-#+end_src
-
-Reference tables in other files with ~@org:path/to/file.org:table-name~.
-
-** COMMENT Combining Sources
-
-Join an org table with Elisp data:
-#+begin_src elisp :results code
-(let ((sales '(((sku . "A-100") (qty . 10))
-               ((sku . "A-100") (qty . 5))
-               ((sku . "C-300") (qty . 20)))))
-  (duckdb-query
-   "SELECT i.product,
-           SUM(s.qty) as sold,
-           i.stock - SUM(s.qty) as remaining
-    FROM @org:inventory i
-    JOIN @sales s ON i.sku = s.sku
-    GROUP BY i.product, i.stock"
-   :data `((sales . ,sales))))
-#+end_src
-
-Join a remote Parquet file with local Elisp configuration:
-#+begin_src elisp :results code
- (let ((airports '(((code . "JFK")
-                   (name . "JFK International"))
-                  ((code . "LGA")
-                   (name . "LaGuardia")))))
-  (duckdb-query
-   "SELECT a.name,
-           COUNT(*) as departures,
-           ROUND(AVG(f.dep_delay), 1) as avg_delay
-    FROM 'https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet' as f
-    JOIN @airports a ON f.origin = a.code
-    GROUP BY a.name
-    ORDER BY departures DESC"
-   :data `((airports . ,airports))))
-
-;; => (((name . "JFK International") (departures . 111279) (avg_delay . 12.1))
-;;     ((name . "LaGuardia") (departures . 104662) (avg_delay . 10.3)))
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-(((name . "JFK International") (departures . 111279) (avg_delay . 12.1))
- ((name . "LaGuardia") (departures . 104662) (avg_delay . 10.3)))
-#+end_src
-
-** COMMENT Output Formats
-
-The ~:format~ parameter controls result structure:
-
-| Format       | Structure                 | Use Case                      |
-|--------------+---------------------------+-------------------------------|
-| ~:alist~     | List of alists            | General Elisp processing      |
-| ~:plist~     | List of plists            | Keyword-based access          |
-| ~:hash~      | List of hash-tables       | O(1) field lookup             |
-| ~:vector~    | Vector of alists          | Index-based access            |
-| ~:columnar~  | Alist of column vectors   | Numerical analysis            |
-| ~:org-table~ | List of lists with header | Display, org-mode integration |
-| ~:raw~       | JSON string               | Custom parsing                |
-
-** COMMENT Schema Introspection
-Discover structure before querying:
-
-#+begin_src elisp :results code :exports both
-(duckdb-query-column-types "SELECT 1 as id, 'text' as name, 3.14 as value")
-;; => (("id" . "INTEGER") ("name" . "VARCHAR") ("value" . "DECIMAL(3,2)"))
-#+end_src
-
-#+begin_src elisp :results code :exports both
-(duckdb-query-columns
- "https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet")
-
-;; => ("year" "month" "day" "dep_time" "sched_dep_time" "dep_delay" "arr_time"
-;;     "sched_arr_time" "arr_delay" "carrier" "flight" "tailnum" "origin" "dest"
-;;     "air_time" "distance" "hour" "minute" "time_hour")
-#+end_src
-
-** COMMENT Database Persistence
-
-#+begin_src elisp :results code
-(duckdb-query-with-transient-database
-  (duckdb-query
-   "CREATE TABLE events (id INT, name TEXT)")
-  (duckdb-query
-   "INSERT INTO events VALUES
-    (1, 'click'), (2, 'scroll')")
-  (duckdb-query "SELECT * FROM events"))
-#+end_src
-
-#+results:
-#+begin_src elisp
-(((id . 1) (name . "click")) ((id . 2) (name . "scroll")))
-#+end_src
-
-
-~duckdb-query-with-transient-database~ creates a temporary file deleted after the
-block. Use ~duckdb-query-with-database~ for persistent files:
-
-#+begin_src elisp :results code
-(duckdb-query-with-database '("analytics.duckdb")
-  (duckdb-query "SELECT COUNT(*) FROM events"))
-#+end_src
-** COMMENT Nested Types
-
-DuckDB supports STRUCT, LIST, MAP, and ARRAY types. These serialize correctly as
-nested Elisp structures:
-
-#+begin_src elisp :results code
-(duckdb-query
- "SELECT
-    {'x': 1, 'y': 2}::STRUCT(x INT, y INT)
-    as point")
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-(((point (x . 1) (y . 2))))
-#+end_src
-
-#+begin_src elisp :results code
-;; Nested data survives roundtrips
-(let ((data
-       '(((id . 1) (loc (x . 10) (y . 20)))
-         ((id . 2) (loc (x . 30) (y . 40))))))
-  (duckdb-query
-   "SELECT id, loc.x + loc.y as sum
-    FROM @data"
-   :data data))
-#+end_src
-
-#+RESULTS:
-#+begin_src elisp
-(((id . 1) (sum . 30)) ((id . 2) (sum . 70)))
-#+end_src
-
-** COMMENT Performance
-
-The package writes results to temporary files by default, providing 3-5x speedup
-on large results compared to streaming through stdout:
-
-: | Result Size | Default (file) | Streaming (pipe) | Speedup |
-: |-------------+----------------+------------------+---------|
-: | 10k rows    | 64ms           | 162ms            | 2.5x    |
-: | 100k rows   | 366ms          | 1.28s            | 3.5x    |
-: | 500k rows   | 1.32s          | 6.19s            | 4.7x    |
-
-Force streaming mode with ~:output-via :pipe~ when needed. DDL statements
-automatically use streaming since they cannot be wrapped in file output.
-
-Profile your specific queries with the benchmark module:
-
-#+begin_src elisp
-(duckdb-query-bench-output-strategies
- "SELECT * FROM range(10000) t(i)"
- :iterations 3)
-#+end_src
-
-#+RESULTS:
-| strategy | mean    | min     | max     | n |
-| :file    | 20.62ms | 20.12ms | 21.52ms | 3 |
-| :pipe    | 20.84ms | 20.50ms | 21.42ms | 3 |
-| :speedup | 1.01x   |         |         |   |
-
-Other benchmark functions: ~duckdb-query-bench-formats~ (compare output formats),
-~duckdb-query-bench-nested-types~ (compare nested type handling),
-~duckdb-query-bench-data-formats~ (compare ~:data~ serialization).
-
-** COMMENT Acknowledgements
-
-- [[https://github.com/ak-coram/cl-duckdb][cl-duckdb]] by Ákos Kiss: The Common Lisp DuckDB wrapper that inspired this
-  package's design philosophy. The approach of treating query results as native
-  Lisp data structures, the ~with-static-table~ pattern for querying Lisp data
-  directly, and the ~with-transient-connection~ / ~with-default-connection~
-  macros for database context management all informed the design of
-  duckdb-query's ~:data~ parameter, ~@org:~ references, and
-  ~duckdb-with-transient-database~ / ~duckdb-with-database~ forms.
-
-** COMMENT Related Packages
-- [[https://github.com/jhinch/ob-duckdb][ob-duckdb]]: Org Babel integration for DuckDB source blocks. SOON I'll add most
-  of the functionalities here to it via a specialized ob-duckdb-query executor,
-  this will allow org-table reference in duckdb-sql source blocks and new output
-  types.
-
-** Integration
-:PROPERTIES:
-:CUSTOM_ID: integration
-:END:
-
-#+begin_quote
-[!WARNING]
-UNDER CONSTRUCTION
-#+end_quote
-
-As mentioned before, sessions allow low-latency, fast response times, going as
-low as 2ms on frequent, repeating small queries like batched updates/inserts and
-single row extraction. Add to this persistent session processes that can
-communicate between each other via database ~ATTACH~/~DETACH~ or external file
-output/input, and we have the *foundation for database-backed major modes, worker
-pools, and orchestrated data pipelines within Emacs.*
-
-
-*** Buffer-Local Sessions
-
-The ~duckdb-query-session-setup-buffer~ helper attaches a session to the current
-buffer. It creates the session if needed, registers the buffer as an owner, and
-sets up the buffer-local binding so all ~duckdb-query~ calls within that buffer
-automatically route to the session. The session persists while any owning buffer
-exists and is killed when the last owner closes:
-
-#+begin_src elisp
-(add-hook 'my-data-mode-hook
-          (lambda ()
-            (duckdb-query-session-setup-buffer "my-data-session")))
-;; All my-data-mode buffers share one session
-;; Session killed when last my-data-mode buffer closes
-#+end_src
-
-This pattern enables major modes that maintain persistent analytical state. A
-dashboard mode might cache expensive aggregations in session tables and refresh
-instantly on demand:
-
-#+begin_src elisp
-(define-derived-mode my-dashboard-mode special-mode "Dashboard"
-  (duckdb-query-session-setup-buffer "dashboard")
-  (setq-local revert-buffer-function #'my-dashboard-refresh))
-
-(defun my-dashboard-refresh (&rest _)
-  "Refresh dashboard from session's cached aggregations."
-  (let ((data (duckdb-query "SELECT * FROM cached_metrics")))
-    (my-dashboard-render data)))
-#+end_src
-
-*** Lifecycle Hooks
-
-Three hooks provide visibility into session activity, enabling logging, metrics
-collection, and cross-session coordination:
-
-#+begin_src elisp
-;; Log all queries with timing
-(add-hook 'duckdb-query-session-query-executed-functions
-          (lambda (name query duration-ms)
-            (message "[%s] %.1fms: %s"
-                     name duration-ms
-                     (truncate-string-to-width query 60))))
-
-;; Track session lifecycle
-(add-hook 'duckdb-query-session-created-functions
-          (lambda (name _session)
-            (message "Session started: %s" name)))
-
-(add-hook 'duckdb-query-session-killed-functions
-          (lambda (name)
-            (message "Session ended: %s" name)))
-#+end_src
-
-These hooks will be essential for building a coordinator layer that manages
-worker sessions, tracks query performance across the system, and handles
-failover when sessions die unexpectedly.
-
-*** Future Directions
-
-This infrastructure opens up architectural patterns that go beyond single-query
-workflows. The ultimate goal is to enable the creation of data-centric emacs
-packages and tools, such as:
-
-- quickly retrieving tabular data from most filetypes or complex queries
-- perform tens to hundreds of CRUD operations per second
-- manage and orchestrate data processing jobs across multiple workers from a central coordinator
-- leverage [[https://github.com/cwida/duckpgq-extension][graph queries]], [[https://github.com/duckdb/duckdb-spatial][geo-spatial processing]], [[https://github.com/duckdb/duckdb-vss][vector similarity search]] and other techniques inside Emacs
-
-Some directions still in design:
-
-- *Database-backed buffers*: Major modes where buffer content is backed by
-  session tables, enabling SQL-powered search, filter, and transform operations
-  that would be impractical with pure Elisp
-- *Worker pools*: Multiple sessions processing jobs in parallel, coordinated
-  through a shared database via ~ATTACH~ or message-passing through elisp.
-- *Live dashboards*: Buffers that subscribe to query results and refresh
-  automatically when underlying data changes
-
-I'll update this section as these experiments mature into usable packages.
+~@org:table-name~ syntax. These combine freely with file paths and URLs in joins,
+unions, and subqueries. A query can join a remote Parquet file with a ten-row
+org table and a runtime Elisp variable, returning the result as an alist you can
+immediately process.
 
 * Quick Examples
+#+begin_quote
+[!TIP]
+Disclaimer: If you want to read this inside emacs in an org-mode buffer,
+you can check the [[file:README-EMACS.org][this version]]: same contents but without any of the html so you
+can test all source blocks directly..
+#+end_quote
+
+All of these are executable, copy them into an org mode source block or execute
+them directly to try them out after installing the package.
 #+begin_html
 <table align="center"><tr>
     <th width="500px">Code</th>
     <th width="500px">Result</th></tr>
 <tr><td>
-<pre lang="elisp">;; List of alists (default)
+<pre lang="emacs-lisp">;; List of alists (default)
 (duckdb-query
- "SELECT 'Alice' as name, 95 as score
-  UNION ALL SELECT 'Bob', 87")</pre>
+ "SELECT name:'Alice', score:95
+  UNION ALL
+    SELECT 'Bob', 87")</pre>
 </td><td>
-<pre lang="elisp">(((name . "Alice") (score . 95))
+<pre lang="emacs-lisp">(((name . "Alice") (score . 95))
  ((name . "Bob") (score . 87)))</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+<tr><td>
+<pre lang="emacs-lisp">
+;; Single value extraction
+(duckdb-query
+ "FROM range(1000)
+  SELECT COUNT(*)"
+ :format :single)</pre>
+</td><td>
+<pre lang="emacs-lisp">1000</pre>
 </td></tr>
 
 <!-- spacing -->
 <tr></tr>
 
 <tr><td>
-<pre lang="elisp">;; Org-table format for display
+<pre lang="emacs-lisp">;; Single row as alist
 (duckdb-query
- "SELECT * FROM range(1,4) t(n),
-   (SELECT unnest(['a','b']) as letter)"
+ "SELECT name:'Alice',
+         score: 95,
+         grade: 'A'"
+ :format :row)</pre>
+</td><td>
+<pre lang="emacs-lisp">((name . "Alice")
+ (score . 95)
+ (grade . "A"))</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">;; Single column as list
+(duckdb-query
+ "SELECT
+     unnest(['red','green','blue'])
+  as color"
+ :format :column)</pre>
+</td><td>
+<pre lang="emacs-lisp">("red" "green" "blue")</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">
+;; Org-table format for display
+(duckdb-query
+ "FROM range(1,4) t(n),
+ (SELECT letter: unnest(['a','b']))"
  :format :org-table)</pre>
 </td><td>
 <pre>
@@ -528,56 +152,236 @@ I'll update this section as these experiments mature into usable packages.
 <tr></tr>
 
 <tr><td>
-<pre lang="elisp">;; Single value extraction
-(duckdb-query-value
- "SELECT COUNT(*) FROM range(1000)")</pre>
-</td><td>
-<pre lang="elisp">1000</pre>
-</td></tr>
-
-<!-- spacing -->
-<tr></tr>
-
-<tr><td>
-<pre lang="elisp">;; Single column as list
-(duckdb-query-column
- "SELECT unnest(
- ['red','green','blue']) as color")</pre>
-</td><td>
-<pre lang="elisp">("red" "green" "blue")</pre>
-</td></tr>
-
-<!-- spacing -->
-<tr></tr>
-
-<tr><td>
-<pre lang="elisp">;; Columnar format for analysis
+<pre lang="emacs-lisp">;; Columnar format for analysis
 (duckdb-query
- "SELECT * FROM range(5) t(n)"
+ "SELECT n, n * 2 as doubled
+  FROM range(5) t(n)"
  :format :columnar)</pre>
 </td><td>
-<pre lang="elisp">((n . [0 1 2 3 4]))</pre>
-</td></tr></table>
+<pre lang="emacs-lisp">((n . [0 1 2 3 4])
+ (doubled . [0 2 4 6 8]))</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">
+;; Safe parameterization with @val:
+(duckdb-query
+ "SELECT * FROM range(10) t(n)
+  WHERE n > @val:threshold"
+ :val '((threshold . 5))
+ :format :column)</pre>
+</td><td>
+<pre lang="emacs-lisp">(6 7 8 9)</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">;; Query fragment composition
+(duckdb-query
+ "SELECT * FROM (@sql:source)
+  WHERE n > 2"
+ :sql '((source .
+         "SELECT * FROM range(5) t(n)"))
+ :format :column)</pre>
+</td><td>
+<pre lang="emacs-lisp">(3 4)</pre>
+</td></tr>
+</table>
 #+end_html
+
+For advanced parameterization including computed thresholds, sequential variable
+dependencies, and fragment composition with embedded references, see
+[[#parameterized-queries][Parameterized Queries]].
 * Contents :noexport:
 :PROPERTIES:
 :TOC:      :include siblings :depth 1 :ignore this
 :END:
 :CONTENTS:
+- [[#installation][Installation]]
+- [[#configuration][Configuration]]
 - [[#querying-elisp-data][Querying Elisp Data]]
 - [[#querying-org-tables][Querying Org Tables]]
 - [[#combining-sources][Combining Sources]]
+- [[#parameterized-queries][Parameterized Queries]]
 - [[#output-formats][Output Formats]]
 - [[#schema-introspection][Schema Introspection]]
 - [[#database-persistence][Database Persistence]]
-- [[#new-session-based-execution][(NEW) Session-Based Execution]]
+- [[#session-based-execution][Session-Based Execution]]
 - [[#nested-types][Nested Types]]
 - [[#performance][Performance]]
+- [[#font-lock-for-reference-syntax][Font Lock for Reference Syntax]]
+- [[#sql-completion][SQL Completion]]
 - [[#acknowledgements][Acknowledgements]]
 - [[#related-packages][Related Packages]]
 - [[#integration][Integration]]
 :END:
 
+* Installation
+:PROPERTIES:
+:CUSTOM_ID: installation
+:END:
+duckdb-query is available on MELPA. Install with =M-x package-install= ⏎ =duckdb-query=.
+Requires the =duckdb= CLI executable in your PATH. Install from [[https://duckdb.org/docs/installation/][duckdb.org]] or via package manager:
+
+#+begin_src shell
+brew install duckdb # macOS
+sudo apt install duckdb # Ubuntu/Debian
+# Or download directly from duckdb.org
+#+end_src
+
+- MELPA (recommended) ::
+#+begin_src emacs-lisp
+(use-package duckdb-query
+  :ensure t)
+#+end_src
+
+- use-package with vc (Emacs 30+) ::
+#+begin_src emacs-lisp
+(use-package duckdb-query
+  :vc (:url "https://github.com/gggion/duckdb-query.el"
+       :rev :newest))
+#+end_src
+
+- Straight or Elpaca ::
+#+begin_src emacs-lisp
+(straight-use-package 'duckdb-query)
+;; OR
+(elpaca duckdb-query)
+#+end_src
+
+The core =duckdb-query= function works immediately after installation.  For
+optional editor enhancements (syntax highlighting and completion inside SQL
+strings), see [[#configuration][Configuration]].
+* Configuration
+:PROPERTIES:
+:CUSTOM_ID: configuration
+:END:
+
+The package works out of the box with sensible defaults. The =duckdb-query=
+function requires no configuration. See =M-x customize-group RET duckdb-query RET=
+for all options.
+
+** Key Variables
+
+- ~duckdb-query-executable~ : Path to DuckDB CLI (default: ="duckdb"=)
+- ~duckdb-query-default-timeout~ : Query timeout in seconds (default: =30=)
+- ~duckdb-query-null-value~ : Elisp representation of SQL NULL (default: =:null=)
+- ~duckdb-query-false-value~ : Elisp representation of SQL FALSE (default: =:false=)
+
+** Editor Support for SQL Strings (Optional)
+
+Two optional minor modes enhance editing =duckdb-query= SQL strings. These are
+not required for the package to function but improve the development experience
+when writing queries in Elisp or Org buffers:
+
+- ~duckdb-query-font-lock-mode~ : Highlights =@type:name= references with
+  validation. Invalid references (undefined bindings, invalid context) show a
+  warning face. Works in =emacs-lisp-mode= buffers and inside org-mode src
+  blocks.
+
+- ~duckdb-query-complete-mode~ : Provides completion-at-point for reference
+  names, SQL keywords, functions, and types. Works with corfu, company-mode, and
+  the default completion UI. In org-mode, narrows to the current src block for
+  efficient parsing.
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-query-font-completion.png?raw=true" align="center" width="100%">
+#+HTML: <p align="center"><em>Example with both modes enabled, autocompletion and custom reference highlights</em></p>
+
+Both modes are independent and share the same structural parser.
+
+*** Enabling via use-package
+
+#+begin_src emacs-lisp
+(use-package duckdb-query
+  :ensure t
+  :config
+  (add-hook 'emacs-lisp-mode-hook #'duckdb-query-font-lock-mode)
+  (add-hook 'emacs-lisp-mode-hook #'duckdb-query-complete-mode)
+  (add-hook 'org-mode-hook #'duckdb-query-complete-mode))
+#+end_src
+
+*** Enabling Manually
+
+#+begin_src emacs-lisp
+;; Highlight @type:name references with validation
+(add-hook 'emacs-lisp-mode-hook #'duckdb-query-font-lock-mode)
+
+;; Complete reference names, SQL keywords, functions, and types
+(add-hook 'emacs-lisp-mode-hook #'duckdb-query-complete-mode)
+(add-hook 'org-mode-hook #'duckdb-query-complete-mode)
+#+end_src
+
+Adding ~duckdb-query-font-lock-mode~ to =emacs-lisp-mode-hook= also highlights
+references inside org-mode =emacs-lisp= src blocks automatically. In org's
+fontification buffers, the mode activates with minimal overhead. To disable
+highlighting in org src blocks entirely:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-font-lock-in-org-src-blocks nil)
+#+end_src
+
+*** Performance in Large Buffers
+
+Both modes accept buffer size thresholds. When set, the modes skip their
+expensive operations in buffers exceeding the threshold:
+
+#+begin_src emacs-lisp
+;; Skip reference fontification in large buffers
+(setq duckdb-query-font-lock-max-buffer-size 512000)  ; 500KB
+
+;; Skip completion in large buffers
+(setq duckdb-query-complete-max-buffer-size 512000)    ; 500KB
+#+end_src
+
+For font-lock, the threshold applies to both standalone =.el= files and the org
+buffer that triggered src block fontification. For completion, the threshold
+applies to the buffer where completion is invoked.
+
+*** Completion Trigger Behavior
+
+The completion mode provides candidates when triggered. Whether candidates
+appear automatically on each keypress or only on explicit invocation depends
+on your completion framework:
+
+| Framework | Automatic (on keypress)      | Manual trigger        |
+|-----------+------------------------------+-----------------------|
+| Corfu     | ~corfu-auto~ non-nil         | ~completion-at-point~ |
+| Company   | ~company-idle-delay~ non-nil | ~company-complete~    |
+| Default   | N/A (always manual)          | =C-M-i=              |
+
+To suppress SQL keyword/function completion during automatic (idle) completion
+while keeping it available on explicit invocation:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-complete-trigger 'manual)
+#+end_src
+
+With this setting, SQL metadata candidates only appear when you explicitly
+invoke completion. Reference completion (=@type:name=) always activates
+regardless of this setting, since typing =@= is already an explicit action.
+
+*** Customizing Completion Behavior
+
+The completion mode queries DuckDB metadata once at enable time and caches
+approximately 3400 candidates (keywords, functions, types). To refresh after
+loading extensions or attaching databases:
+
+#+begin_src
+M-x duckdb-query-complete-refresh-cache
+#+end_src
+
+To disable SQL metadata completion and keep only reference completion:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-complete-sql-p nil)
+#+end_src
+
+See [[#font-lock-for-reference-syntax][Font Lock for Reference Syntax]] and [[#sql-completion][SQL Completion]] for full documentation.
 * Querying Elisp Data
 :PROPERTIES:
 :CUSTOM_ID: querying-elisp-data
@@ -591,7 +395,7 @@ named ~@data~:
     <th width="500px">Code</th>
     <th width="500px">Result</th></tr>
 <tr><td>
-<pre lang="elisp">(duckdb-query
+<pre lang="emacs-lisp">(duckdb-query
  "SELECT name, score * 1.1 as curved
   FROM @data
   WHERE score > 85"
@@ -599,7 +403,7 @@ named ~@data~:
          ((name . "Bob") (score . 87))
          ((name . "Carol") (score . 72))))</pre>
 </td><td>
-<pre lang="elisp">(((name . "Aly") (curved . 104.5))
+<pre lang="emacs-lisp">(((name . "Aly") (curved . 104.5))
  ((name . "Bob") (curved . 95.7)))</pre>
 </td></tr></table>
 #+end_html
@@ -612,7 +416,7 @@ variables:
     <th width="500px">Code</th>
     <th width="500px">Result</th></tr>
 <tr><td>
-<pre lang="elisp"> (let ((users ;; users table
+<pre lang="emacs-lisp"> (let ((users ;; users table
        '(((id . 1) (name . "Alice"))
          ((id . 2) (name . "Bob"))))
       (orders ;; orders table
@@ -627,7 +431,7 @@ variables:
    :data `((users . ,users)
            (orders . ,orders))))</pre>
 </td><td>
-<pre lang="elisp">
+<pre lang="emacs-lisp">
 (((name . "Alice") (count . 2))
  ((name . "Bob") (count . 1)))
 </pre>
@@ -666,7 +470,7 @@ buffer:
     <th width="500px">Code</th>
     <th width="500px">Result</th></tr>
 <tr><td>
-<pre lang="elisp">(duckdb-query
+<pre lang="emacs-lisp">(duckdb-query
  "SELECT product,
     stock * price as value
   FROM @org:inventory
@@ -697,7 +501,7 @@ Join an org table with Elisp data:
     <th width="500px">Code</th>
     <th width="500px">Result</th></tr>
 <tr><td>
-<pre lang="elisp">(let ((sales '(((sku . "A-100") (qty . 10))
+<pre lang="emacs-lisp">(let ((sales '(((sku . "A-100") (qty . 10))
                ((sku . "A-100") (qty . 5))
                ((sku . "C-300") (qty . 20)))))
   (duckdb-query
@@ -705,11 +509,11 @@ Join an org table with Elisp data:
            SUM(s.qty) as sold,
            i.stock - SUM(s.qty) as remaining
     FROM @org:inventory i
-    JOIN @sales s ON i.sku = s.sku
+    JOIN @data:sales s ON i.sku = s.sku
     GROUP BY i.product, i.stock"
    :data `((sales . ,sales))))</pre>
 </td><td>
-<pre lang="elisp">(((product . "Widget")
+<pre lang="emacs-lisp">(((product . "Widget")
   (sold . 15)
   (remaining . 35))
  ((product . "Gizmo")
@@ -719,17 +523,16 @@ Join an org table with Elisp data:
 #+end_html
 
 Join a remote Parquet file with local Elisp data:
-#+begin_src elisp :results code
- (let ((airports '(((code . "JFK")
-                   (name . "JFK International"))
-                  ((code . "LGA")
-                   (name . "LaGuardia")))))
+
+#+begin_src elisp
+(let ((airports '(((code . "JFK") (name . "JFK International"))
+                  ((code . "LGA") (name . "LaGuardia")))))
   (duckdb-query
    "SELECT a.name,
            COUNT(*) as departures,
            ROUND(AVG(f.dep_delay), 1) as avg_delay
-    FROM 'https://github.com/rfsaldanha/releases/releases/download/v1/flights.parquet' as f
-    JOIN @airports a ON f.origin = a.code
+    FROM 'https://github.com/.../flights.parquet' f
+    JOIN @data:airports a ON f.origin = a.code
     GROUP BY a.name
     ORDER BY departures DESC"
    :data `((airports . ,airports))))
@@ -738,22 +541,463 @@ Join a remote Parquet file with local Elisp data:
 ;;     ((name . "LaGuardia") (departures . 104662) (avg_delay . 10.3)))
 #+end_src
 
+Here's an example combining ~@data~, ~@org~ and ~@val~ in a single query using the
+same ~inventory~ table from the previous section:
+
+#+begin_html
+<table align="center"><tr>
+    <th width="500px">Code</th>
+    <th width="500px">Result</th></tr>
+<tr><td>
+<pre lang="emacs-lisp">;; Using #+NAME: inventory from above
+(let ((sales '(((sku . "A-100") (qty . 15))
+               ((sku . "C-300") (qty . 25)))))
+  (duckdb-query
+   "SELECT i.product,
+           s.qty as sold,
+           s.qty * i.price as revenue
+    FROM @org:inventory i
+    JOIN @data:sales s ON i.sku = s.sku
+    WHERE i.price >= @val:min_price
+    ORDER BY revenue DESC"
+   :data `((sales . ,sales))
+   :val '((min_price . 10))))</pre>
+</td><td>
+<pre lang="emacs-lisp">(((product . "Gizmo")
+  (sold . 25)
+  (revenue . 374.75))
+ ((product . "Widget")
+  (sold . 15)
+  (revenue . 149.85)))</pre>
+</td></tr></table>
+<p align="center"><em>Combining @val, @org and @data references in one query</em></p>
+#+end_html
+
+* Parameterized Queries
+:PROPERTIES:
+:CUSTOM_ID: parameterized-queries
+:END:
+
+The package provides parameterization through the =@type:name= reference pattern.
+All references follow the same syntax but serve different purposes and have
+different safety characteristics.
+
+** Reference Type Summary
+:PROPERTIES:
+:CUSTOM_ID: reference-type-summary
+:END:
+
+| Type   | Syntax              | Parameter | Mechanism                      | Use Case                        |
+|--------+---------------------+-----------+--------------------------------+---------------------------------|
+| =@org:=  | =@org:table=          | --        | Resolve org table to JSON file | Org table data                  |
+|        | =@org:file:table=     |           |                                | Org table from specific file    |
+| =@data:= | =@data:name= or =@name= | =:data=     | Serialize Elisp to JSON file   | Elisp data structures           |
+| =@val:=  | =@val:name=           | =:val=      | =SET VARIABLE= with SQL literal  | Literal values (injection-safe) |
+| =@sql:=  | =@sql:name=           | =:sql=      | Direct text substitution       | Query fragments, identifiers    |
+
+The reference type in your query must match the parameter:
+- =@val:x= requires =x= to be in =:val=
+- =@sql:x= requires =x= to be in =:sql=
+- =@data:x= requires =x= to be in =:data=
+
+Mismatches signal an error with a helpful message indicating which parameter is missing.
+
+** Substitution Order
+
+References are processed in strict order, enabling powerful composition:
+
+1. =@sql:= -- Text substitution first (fragments can contain other reference types)
+2. =@org:= -- Org tables resolved to temp JSON files
+3. =@data:= -- Elisp data serialized to temp JSON files
+4. =@val:= -- Variable bindings generated as =SET VARIABLE= statements
+
+This ordering is critical: =@sql:= fragments can contain =@val:=, =@data:=, and =@org:=
+references that resolve in subsequent passes.
+
+** Variable Binding with =@val:=
+
+The =:val= parameter binds Elisp values as DuckDB session variables. Values are
+converted to SQL literals with proper escaping, making this safe for user input:
+
+#+begin_html
+<table align="center"><tr>
+    <th width="500px">Code</th>
+    <th width="500px">Generated SQL</th></tr>
+<tr><td>
+<pre lang="emacs-lisp">(duckdb-query
+ "SELECT * FROM users
+  WHERE name LIKE @val:pattern
+    AND age >= @val:min_age"
+ :val '((pattern . "%O'Brien%")
+        (min_age . 18)))</pre>
+</td><td>
+<pre lang="sql">SET VARIABLE pattern = '%O''Brien%';
+SET VARIABLE min_age = 18;
+SELECT * FROM users
+WHERE name LIKE getvariable('pattern')
+  AND age >= getvariable('min_age')</pre>
+</td></tr></table>
+#+end_html
+
+Variables support all DuckDB types with automatic conversion:
+
+| Elisp Value          | SQL Generated    | DuckDB Type |
+|----------------------+------------------+-------------|
+| =42=                   | =42=               | INTEGER     |
+| =3.14159=              | =3.14159=          | DOUBLE      |
+| ="O'Brien"=            | ='O''Brien'=       | VARCHAR     |
+| =t=                    | =TRUE=             | BOOLEAN     |
+| =:false=               | =FALSE=            | BOOLEAN     |
+| =:null= or =nil=         | =NULL=             | NULL        |
+| =[1 2 3]=              | =[1, 2, 3]=        | INTEGER[]   |
+| =((a . 1) (b . 2))=    | ={'a': 1, 'b': 2}= | STRUCT      |
+| =(sql "(SELECT ...)")= | =(SELECT ...)=     | (evaluated) |
+
+Bound values are native DuckDB types, enabling struct field access and array operations:
+
+#+begin_src elisp
+;; Struct field access
+(duckdb-query "SELECT @val:person.name AS n, @val:person.age AS a"
+              :val '((person . ((name . "Alice") (age . 30)))))
+;; => (((n . "Alice") (a . 30)))
+
+;; Array operations
+(duckdb-query "SELECT list_sum(@val:nums) AS total, @val:nums[2] AS second"
+              :val '((nums . [10 20 30])))
+;; => (((total . 60) (second . 20)))
+#+end_src
+
+*** Sequential Variable Dependencies
+
+Bindings are processed in declaration order like =let*=. Later bindings can
+reference earlier ones using the =(sql ...)= wrapper:
+
+#+begin_html
+<table align="center"><tr>
+    <th width="500px">Code</th>
+    <th width="500px">Result</th></tr>
+<tr><td>
+<pre lang="emacs-lisp">(duckdb-query
+ "SELECT @val:base AS b,
+         @val:doubled AS d,
+         @val:final AS f"
+ :val '((base . 10)
+        (doubled . (sql "@val:base * 2"))
+        (final . (sql "@val:doubled + @val:base"))))</pre>
+</td><td>
+<pre lang="emacs-lisp">(((b . 10) (d . 20) (f . 30)))</pre>
+</td></tr></table>
+#+end_html
+
+The =(sql ...)= wrapper passes its content through unquoted, enabling DuckDB to
+evaluate expressions. Without the wrapper, strings are quoted as literals.
+
+Out-of-order references signal an error:
+
+#+begin_src elisp
+(duckdb-query "SELECT @val:result"
+              :val '((result . (sql "@val:undefined"))
+                     (undefined . 10)))
+;; Error: @val:result in value references undefined variable 'undefined'
+#+end_src
+
+*** Computed Values from Data
+
+The =(sql ...)= expressions can reference =@data:= bindings, enabling dynamic
+thresholds computed from your data:
+
+#+begin_html
+<table align="center"><tr>
+    <th width="500px">Code</th>
+    <th width="500px">Result</th></tr>
+<tr><td>
+<pre lang="emacs-lisp">(let ((scores
+       '(((name . "Alice") (score . 90))
+         ((name . "Bob") (score . 70))
+         ((name . "Carol") (score . 85)))))
+  (duckdb-query
+   "SELECT * FROM @data:scores
+    WHERE score > @val:threshold"
+   :data `((scores . ,scores))
+   :val '((threshold
+           . (sql "(SELECT AVG(score)
+                    FROM @data:scores)")))))</pre>
+</td><td>
+<pre lang="emacs-lisp">(((name . "Alice") (score . 90)))</pre>
+<p><em>Threshold computed as ~81.67</em></p>
+</td></tr></table>
+#+end_html
+
+*** Reference Validity in =(sql ...)= Wrappers
+
+The =(sql ...)= wrapper can contain =@val:= and =@data:= references. However, =@sql:=
+and =@org:= references inside =(sql ...)= cannot be resolved because =@sql:=
+substitution happens before =:val= processing:
+
+| Reference Type | In =(sql ...)= Wrapper |
+|----------------+----------------------|
+| =@val:name=      | Valid                |
+| =@data:name=     | Valid                |
+| =@sql:name=      | Invalid              |
+| =@org:name=      | Invalid              |
+
+#+begin_quote
+[!IMPORTANT]
+Variables are /scalar/ values. They must resolve to exactly one column and one
+row. Subqueries returning multiple columns or rows will error:
+=Binder Error: Subquery returns 2 columns - expected 1=.
+For table-valued data, use =@data:= bindings instead.
+#+end_quote
+
+** Query Fragment Composition with =@sql:=
+
+The =@sql:= reference performs direct text substitution. Use it for query
+fragments, dynamic identifiers, or computed expressions that cannot be
+parameterized as values:
+
+#+begin_html
+<table align="center"><tr>
+    <th width="500px">Code</th>
+    <th width="500px">Result</th></tr>
+<tr><td>
+<pre lang="emacs-lisp">(duckdb-query
+ "SELECT * FROM (@sql:base_query)
+  WHERE value > @val:threshold"
+ :sql '((base_query .
+         "SELECT n AS id, n * 10 AS value
+          FROM range(1, 6) t(n)"))
+ :val '((threshold . 30)))</pre>
+</td><td>
+<pre lang="emacs-lisp">(((id . 4) (value . 40))
+ ((id . 5) (value . 50)))</pre>
+</td></tr></table>
+#+end_html
+
+*** Fragments Can Contain Other References
+
+Since =@sql:= substitution happens first, fragments can contain =@val:=, =@data:=, and
+=@org:= references that resolve in subsequent passes:
+
+#+begin_src elisp
+(duckdb-query
+ "SELECT * FROM (@sql:filtered_data)"
+ :sql '((filtered_data .
+         "SELECT * FROM @data:users
+          WHERE age > @val:min_age"))
+ :data `((users . ,user-list))
+ :val '((min_age . 21)))
+#+end_src
+
+*** Nested Fragment Substitution
+
+Fragments can reference other fragments, enabling modular query construction:
+
+#+begin_src elisp
+(duckdb-query
+ "SELECT * FROM (@sql:outer)"
+ :sql '((outer . "SELECT x, x*2 AS doubled FROM (@sql:inner)")
+        (inner . "SELECT generate_series AS x FROM generate_series(1, 3)")))
+;; => (((x . 1) (doubled . 2)) ((x . 2) (doubled . 4)) ((x . 3) (doubled . 6)))
+#+end_src
+
+*** Dynamic Identifiers
+
+Table names, column names, and other SQL identifiers cannot be parameterized
+with =@val:= (DuckDB treats them as string literals). Use =@sql:= for dynamic
+identifiers:
+
+#+begin_html
+<table align="center"><tr>
+    <th width="500px">Code</th>
+    <th width="500px">Result</th></tr>
+<tr><td>
+<pre lang="emacs-lisp">(duckdb-query
+ "SELECT @sql:columns
+  FROM @sql:source
+  ORDER BY @sql:sort_col DESC
+  LIMIT @val:n"
+ :sql '((source . "range(1, 100) t(n)")
+        (columns . "n, n * 2 AS doubled")
+        (sort_col . "doubled"))
+ :val '((n . 5)))</pre>
+</td><td>
+<pre lang="emacs-lisp">(((n . 99) (doubled . 198))
+ ((n . 98) (doubled . 196))
+ ((n . 97) (doubled . 194))
+ ((n . 96) (doubled . 192))
+ ((n . 95) (doubled . 190)))</pre>
+</td></tr></table>
+#+end_html
+
+*** Reusable Query Libraries
+
+It's also possible to define fragment libraries for common patterns:
+
+#+begin_src elisp
+(defvar my-query-fragments
+  '((active_users . "SELECT * FROM @data:users WHERE status = 'active'")
+    (recent_orders . "SELECT * FROM @data:orders WHERE date > @val:since")))
+
+(let ((users '(((id . 1) (name . "Alice") (status . "active"))
+               ((id . 2) (name . "Bob") (status . "inactive"))
+               ((id . 3) (name . "Carol") (status . "active"))))
+      (orders '(((id . 101) (user_id . 1) (date . "2024-02-15"))
+                ((id . 102) (user_id . 1) (date . "2024-03-01"))
+                ((id . 103) (user_id . 3) (date . "2024-02-20")))))
+  (duckdb-query
+   "SELECT u.name, COUNT(o.id) as order_count
+    FROM (@sql:active_users) u
+    LEFT JOIN (@sql:recent_orders) o ON u.id = o.user_id
+    GROUP BY u.name"
+   :sql my-query-fragments
+   :data `((users . ,users) (orders . ,orders))
+   :val '((since . "2024-01-01"))))
+;; => (((name . "Alice") (order_count . 2))
+;;     ((name . "Carol") (order_count . 1)))
+#+end_src
+
+** Cross-Reference Interaction Guide
+
+This table summarizes which reference types can contain other reference types:
+
+| Container           | Can contain =@sql:= | Can contain =@data:= | Can contain =@val:= | Can contain =@org:= |
+|---------------------+---------------------+----------------------+---------------------+---------------------|
+| Main query          | Yes                 | Yes                  | Yes                 | Yes                 |
+| =@sql:= fragment    | Yes (nested)        | Yes                  | Yes                 | Yes                 |
+| =@val:= =(sql ...)= | No                  | Yes                  | Yes (earlier only)  | No                  |
+
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-font-lock-warning-enabled.png?raw=true" align="center" width="100%">
+#+HTML: <p align="center"><em>TIP: Enabling duckdb-query-font-lock-mode will fontify invalid references with the warning face.</em></p>
+
+** Complete Example: All Reference Types
+
+This example demonstrates all binding types working together:
+
+#+begin_src elisp
+(let ((products '(((sku . "A1") (name . "Widget") (price . 29.99))
+                  ((sku . "B2") (name . "Gadget") (price . 49.99))
+                  ((sku . "C3") (name . "Gizmo") (price . 99.99))))
+      (sales '(((sku . "A1") (qty . 10) (region . "West"))
+               ((sku . "B2") (qty . 5) (region . "East"))
+               ((sku . "C3") (qty . 3) (region . "West")))))
+  (duckdb-query
+   "WITH metrics AS (@sql:metrics_cte)
+    SELECT
+      m.region,
+      m.revenue,
+      @val:avg_revenue AS overall_avg,
+      CASE WHEN m.revenue > @val:high_threshold THEN 'High'
+           WHEN m.revenue > @val:avg_revenue THEN 'Medium'
+           ELSE 'Low'
+      END AS performance
+    FROM metrics m
+    ORDER BY m.revenue DESC"
+
+   :sql '((metrics_cte .
+           "SELECT s.region, SUM(s.qty * p.price) AS revenue
+            FROM @data:sales s
+            JOIN @data:products p ON s.sku = p.sku
+            WHERE p.price >= @val:min_price
+            GROUP BY s.region"))
+
+   :data `((products . ,products)
+           (sales . ,sales))
+
+   :val '((min_price . 25)
+          (avg_revenue . (sql "(SELECT AVG(s.qty * p.price)
+                                FROM @data:sales s
+                                JOIN @data:products p ON s.sku = p.sku)"))
+          (high_threshold . (sql "@val:avg_revenue * 1.5")))
+
+   :format :org-table))
+#+end_src
+
+This query:
+- Uses =@sql:metrics_cte= to define a reusable CTE fragment
+- The fragment contains =@data:= and =@val:= references resolved after substitution
+- Computes =avg_revenue= from bound data using =(sql ...)=
+- Derives =high_threshold= from the computed average using sequential dependency
+- Combines all reference types in a single query
 * Output Formats
 :PROPERTIES:
 :CUSTOM_ID: output-formats
 :END:
+#+begin_quote
+[!IMPORTANT]
+NEW in 0.8:  ~:single~, ~:row~, and ~:column~ formats
+#+end_quote
 
 The ~:format~ parameter controls result structure:
 
-| Format       | Structure                 | Use Case                      |
-|--------------+---------------------------+-------------------------------|
+| Format     | Structure                 | Use Case                      |
+|------------+---------------------------+-------------------------------|
 | ~:alist~     | List of alists            | General Elisp processing      |
 | ~:plist~     | List of plists            | Keyword-based access          |
 | ~:hash~      | List of hash-tables       | O(1) field lookup             |
 | ~:vector~    | Vector of alists          | Index-based access            |
 | ~:columnar~  | Alist of column vectors   | Numerical analysis            |
 | ~:org-table~ | List of lists with header | Display, org-mode integration |
+| ~:single~    | Scalar value              | COUNT, MAX, single lookups    |
+| ~:row~       | Single alist              | Single record extraction      |
+| ~:column~    | List of values            | Single column extraction      |
 | ~:raw~       | JSON string               | Custom parsing                |
+
+The ~:single~, ~:row~, and ~:column~ formats enforce cardinality:
+
+#+begin_html
+<table align="center"><tr>
+    <th width="500px">Code</th>
+    <th width="500px">Result</th></tr>
+<tr><td>
+<pre lang="emacs-lisp">;; :single errors on multiple rows/columns
+(duckdb-query
+ "SELECT 1, 2" :format :single)</pre>
+</td><td>
+<pre lang="emacs-lisp">;; Error: Query returned 2 columns,
+;; expected 1 for :single format</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">;; :row errors on multiple rows
+(duckdb-query
+ "SELECT * FROM range(3) t(n)"
+ :format :row)</pre>
+</td><td>
+<pre lang="emacs-lisp">;; Error: Query returned 3 rows,
+;; expected 1 for :row format</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">;; :column takes first column silently
+(duckdb-query
+ "SELECT n, n*2 FROM range(3) t(n)"
+ :format :column)</pre>
+</td><td>
+<pre lang="emacs-lisp">(0 1 2)</pre>
+</td></tr></table>
+#+end_html
+
+These cardinality checks catch logic bugs early like if you expect one row but
+get three, something is wrong with your query or assumptions.
+
+Additionally, the convenience functions ~duckdb-query-value~, ~duckdb-query-row~,
+and ~duckdb-query-column~ provide the same extraction without ~:format~:
+
+#+begin_src elisp
+(duckdb-query-value "SELECT COUNT(*) FROM range(100)")
+;; => 100
+(duckdb-query-row "SELECT name:'Alice', score:95")
+;; => ((name . "Alice") (score . 95))
+(duckdb-query-column "SELECT unnest([1,2,3])")
+;; => (1 2 3)
+#+end_src
 
 * Schema Introspection
 :PROPERTIES:
@@ -775,58 +1019,88 @@ Discover structure before querying:
 ;;     "air_time" "distance" "hour" "minute" "time_hour")
 #+end_src
 
+#+begin_src elisp :results code :exports both
+(duckdb-query-describe "SELECT 1 as id, 'text' as name")
+;; => (((column_name . "id") (column_type . "INTEGER") (null . "YES") ...)
+;;     ((column_name . "name") (column_type . "VARCHAR") (null . "YES") ...))
+#+end_src
+
 * Database Persistence
-#+begin_quote
-[!TIP]
-*New in 0.7.0*: ~duckdb-query-with-database~ accepts an optional spec list for
-additional options.  Both =(duckdb-query-with-database "path" ...)= and
-=(duckdb-query-with-database '("path" :readonly t) ...)= are supported.
-#+end_quote
+:PROPERTIES:
+:CUSTOM_ID: database-persistence
+:END:
 
 For workflows requiring state across queries, bind a database file:
 
-#+begin_html
-<table align="center"><tr>
-    <th width="500px">Code</th>
-    <th width="500px">Result</th></tr>
-<tr><td>
-<pre lang="elisp">(duckdb-query-with-transient-database
+#+begin_src elisp :results code
+(duckdb-query-with-transient-database
   (duckdb-query
    "CREATE TABLE events (id INT, name TEXT)")
   (duckdb-query
    "INSERT INTO events VALUES
     (1, 'click'), (2, 'scroll')")
-  (duckdb-query "SELECT * FROM events"))</pre>
-</td><td>
-<pre lang="elisp">(((id . 1) (name . "click"))
- ((id . 2) (name . "scroll")))</pre>
-</td></tr></table>
-#+end_html
-
-~duckdb-query-with-transient-database~ creates a temporary file deleted after the
-block. Use ~duckdb-query-with-database~ for persistent files:
-
-#+begin_src elisp
-(duckdb-query-with-database '("analytics.duckdb")
-  (duckdb-query "SELECT COUNT(*) FROM events"))
+  (duckdb-query "SELECT * FROM events"))
+;; => (((id . 1) (name . "click"))
+;;     ((id . 2) (name . "scroll")))
 #+end_src
 
-The spec list accepts keyword options:
+~duckdb-query-with-transient-database~ creates a temporary file deleted after the
+block.  Use ~duckdb-query-with-database~ for persistent files:
 
-#+begin_src elisp
-;; Open read-only to prevent write conflicts
-(duckdb-query-with-database '("/shared/data.db" :readonly t)
-  (duckdb-query "SELECT * FROM reports"))
+#+begin_src elisp :results code
+(duckdb-query-with-database "analytics.duckdb"
+  (duckdb-query "CREATE TABLE events (id INT, name TEXT)")
+  (duckdb-query "INSERT INTO events VALUES (1, 'click')")
+  (duckdb-query "SELECT * FROM events"))
+;; => (((id . 1) (name . "click")))
+#+end_src
 
+Databases open in writable mode by default.  For read-only access, pass a spec
+list with ~:readonly t~:
+
+#+begin_src elisp :results code
+;; Open existing database read-only (prevents accidental writes)
+(duckdb-query-with-database '("analytics.duckdb" :readonly t)
+  (duckdb-query "SELECT * FROM events"))
+#+end_src
+
+#+BEGIN_quote
+[!WARNING]
+When a database path does not exist, DuckDB creates it automatically in
+writable mode.  This means ~:database "new.db"~ or
+~duckdb-query-with-database "new.db"~ will create the file as a side
+effect.  Use ~:readonly t~ to prevent accidental creation -- DuckDB
+signals an error if the file does not exist in read-only mode.
+#+end_quote
+
+The spec list supports variable paths:
+
+#+begin_src elisp :results code
 ;; With variable path
 (let ((db-path "~/project/app.db"))
   (duckdb-query-with-database `(,db-path)
     (duckdb-query "SELECT * FROM users")))
+
+;; Read-only with variable path
+(let ((db-path "~/project/app.db"))
+  (duckdb-query-with-database `(,db-path :readonly t)
+    (duckdb-query "SELECT * FROM users")))
 #+end_src
 
-These macros work with CLI execution. For persistent processes with lower
-latency, see "Session-Based Execution" below.
+The bare ~:database~ parameter in ~duckdb-query~ also defaults to writable:
+
+#+begin_src elisp :results code
+;; Direct parameter -- also writable
+(duckdb-query "SELECT * FROM logs" :database "app.db")
+#+end_src
+
+These macros work with CLI execution.  For persistent processes with lower
+latency, see [[#session-based-execution][Session-Based Execution]] below.
+
 * Session-Based Execution
+:PROPERTIES:
+:CUSTOM_ID: session-based-execution
+:END:
 For repeated queries or workflows requiring persistent state, sessions eliminate
 DuckDB process spawn overhead (~10-20ms per query). A session maintains a
 long-running DuckDB process with its own temporary database:
@@ -916,7 +1190,7 @@ For manual control, use ~duckdb-query-session-attach~ and ~duckdb-query-session-
 ~duckdb-query-with-transient-database~ also adapts to session context:
 
 #+begin_src elisp :results code
-(duckdb-query-with-session "work"
+(duckdb-query-with-transient-session "work"
   (duckdb-query "CREATE TABLE permanent AS SELECT 'stays' as val")
 
   (duckdb-query-with-transient-database
@@ -928,6 +1202,11 @@ For manual control, use ~duckdb-query-session-attach~ and ~duckdb-query-session-
   ;; Back to session context, scratch is gone
   (duckdb-query-value "SELECT val FROM permanent"))
 ;; => "stays"
+#+end_src
+
+#+RESULTS:
+#+begin_src elisp
+"stays"
 #+end_src
 
 ** Session Management
@@ -955,24 +1234,59 @@ Session initialization commands run when sessions start:
 :CUSTOM_ID: nested-types
 :END:
 
-DuckDB supports STRUCT, LIST, MAP, and ARRAY types. These serialize correctly as
-nested Elisp structures:
+DuckDB supports STRUCT, LIST, MAP, and ARRAY types. The default file-based
+output mode serializes these correctly as nested Elisp structures:
 
 #+begin_html
 <table align="center"><tr>
     <th width="500px">Code</th>
     <th width="500px">Result</th></tr>
 <tr><td>
-<pre lang="elisp">(duckdb-query
+<pre lang="emacs-lisp">(duckdb-query
  "SELECT
     {'x': 1, 'y': 2}::STRUCT(x INT, y INT)
     as point")
 </pre>
 </td><td>
-<pre lang="elisp">(((point (x . 1) (y . 2))))</pre>
+<pre lang="emacs-lisp">(((point (x . 1) (y . 2))))</pre>
 </td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
 <tr><td>
-<pre lang="elisp">;; Nested data survives roundtrips
+<pre lang="emacs-lisp">;; Arrays become Elisp lists
+(duckdb-query
+ "SELECT [1, 2, 3] as nums,
+         ['a', 'b'] as letters")</pre>
+</td><td>
+<pre lang="emacs-lisp">(((nums 1 2 3)
+  (letters "a" "b")))</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">;; Nested structs
+(duckdb-query
+ "SELECT
+    {'person':
+      {'name': 'Alice', 'age': 30},
+     'active': true}
+    as record")</pre>
+</td><td>
+<pre lang="emacs-lisp">(((record
+   (person (name . "Alice")
+           (age . 30))
+   (active . t))))</pre>
+</td></tr>
+
+<!-- spacing -->
+<tr></tr>
+
+<tr><td>
+<pre lang="emacs-lisp">;; Nested data survives roundtrips
 (let ((data
        '(((id . 1) (loc (x . 10) (y . 20)))
          ((id . 2) (loc (x . 30) (y . 40))))))
@@ -981,11 +1295,37 @@ nested Elisp structures:
     FROM @data"
    :data data))</pre>
 </td><td>
-<pre lang="elisp">(((id . 1) (sum . 30))
+<pre lang="emacs-lisp">(((id . 1) (sum . 30))
  ((id . 2) (sum . 70)))</pre>
-</td></tr></table>
+</td></tr>
+</table>
 #+end_html
 
+** Pipe Mode and =:preserve-nested=
+
+When using =:output-via :pipe= (streaming mode) or session execution for DDL
+fallback, nested types serialize as DuckDB's string representation instead of
+proper JSON. The =:preserve-nested= parameter wraps nested columns with
+=to_json()= to restore correct serialization:
+
+#+begin_src elisp
+;; Without :preserve-nested in pipe mode
+(duckdb-query "SELECT {'x': 1}::STRUCT(x INT) as s"
+              :output-via :pipe)
+;; => (((s . "{'x': 1}")))  ; String representation
+
+;; With :preserve-nested
+(duckdb-query "SELECT {'x': 1}::STRUCT(x INT) as s"
+              :output-via :pipe
+              :preserve-nested t)
+;; => (((s (x . 1))))  ; Proper nested structure
+#+end_src
+
+The default =:output-via :file= mode handles nested types correctly without
+=:preserve-nested=. Use =:preserve-nested= when:
+- Explicitly requesting =:output-via :pipe=
+- Inside session scope where DDL statements force pipe fallback
+- Roundtripping nested data through =@data:= bindings after pipe-mode queries
 * Performance
 :PROPERTIES:
 :CUSTOM_ID: performance
@@ -1010,7 +1350,9 @@ Profile your specific queries with the benchmark module:
     <th width="500px">Code</th>
     <th width="500px">Result</th></tr>
 <tr><td>
-<pre lang="elisp">(duckdb-query-bench-output-strategies
+<pre lang="emacs-lisp">
+(require 'duckdb-query-bench)
+(duckdb-query-bench-output-strategies
  "SELECT * FROM range(10000) t(i)"
  :iterations 3)</pre>
 </td><td>
@@ -1026,6 +1368,153 @@ Other benchmark functions: ~duckdb-query-bench-formats~ (compare output formats)
 ~duckdb-query-bench-nested-types~ (compare nested type handling),
 ~duckdb-query-bench-data-formats~ (compare ~:data~ serialization).
 
+#+begin_quote
+[!NOTE]
+I'm in the process of adding more benchmark utilities geared towards measuring performance for parameterized queries.
+#+end_quote
+
+* Font Lock for Reference Syntax
+:PROPERTIES:
+:CUSTOM_ID: font-lock-for-reference-syntax
+:END:
+
+The =duckdb-query-font-lock-mode= minor mode highlights =@type:name= references
+inside SQL strings passed to =duckdb-query=, =duckdb-query-value=,
+=duckdb-query-row=, and =duckdb-query-column=.
+
+References are highlighted only within recognized function calls, not in
+docstrings, comments, or other string contexts. When added to
+=emacs-lisp-mode-hook=, the mode also activates in org-mode src blocks with
+lightweight overhead (keywords only, no preset application or region extension
+hooks).
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-font-lock-enabled.png?raw=true" align="center" width="100%">
+
+Invalid references are highlighted with a warning face. This'll apply to names
+not found in the corresponding =:sql=, =:data=, or =:val= parameter, and also to
+references which are not compatible inside one another (for more info, see [[#reference-type-summary][Reference Type Summary]]).
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-font-lock-warning-enabled.png?raw=true" align="center" width="100%">
+
+** Preset Selection
+
+Nine highlighting presets are available. Select interactively with live preview:
+
+#+begin_src
+M-x duckdb-query-font-lock-select-preset
+#+end_src
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-query-1_2180x2220.gif?raw=true" align="center" width="100%">
+Or set directly:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-font-lock-preset 'shadow-bold-constant)  ; default
+;; Other presets: shadow-bold-variable, keyword-variable, uniform-type,
+;; uniform-keyword, italic-shadow-bold-constant, light-extra-bold,
+;; shadow-completions, italic-shadow-bold-underline
+#+end_src
+
+** Custom Faces
+
+For fine-grained control, customize the faces directly:
+
+- ~duckdb-query-reference-prefix-face~: The =@type:= portion
+- ~duckdb-query-reference-name-face~: The =name= portion
+- ~duckdb-query-reference-invalid-face~: Undefined or invalid references
+
+#+begin_src emacs-lisp
+(set-face-attribute 'duckdb-query-reference-prefix-face nil
+                    :inherit 'shadow :slant 'italic)
+(set-face-attribute 'duckdb-query-reference-name-face nil
+                    :inherit 'font-lock-constant-face :weight 'bold)
+#+end_src
+
+* SQL Completion
+:PROPERTIES:
+:CUSTOM_ID: sql-completion
+:END:
+
+The =duckdb-query-complete-mode= minor mode provides completion-at-point inside
+SQL string arguments to =duckdb-query= and related functions. It works with
+corfu, company-mode, and the default completion UI.
+
+Three completion contexts activate depending on cursor position within a SQL
+string:
+
+- Reference Completion ::
+
+Typing =@= triggers reference type completion, offering =sql:=, =data:=, =val:=,
+and =org:= as candidates with descriptions. After selecting a type (or typing it
+manually), the completion system reads binding names from the corresponding
+parameter in the same =duckdb-query= form.
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-complete-example_2000x1800.gif?raw=true" align="center" width="100%">
+
+Reference completion is exclusive: when active, other completion sources do not
+contribute conflicting candidates.
+
+- SQL Keyword, Function, and Type Completion ::
+
+Outside of =@type:= contexts, the mode completes SQL keywords, functions, and
+data types from cached DuckDB metadata. The cache populates once at mode enable
+by querying =duckdb_keywords()=, =duckdb_functions()=, and =duckdb_types()=,
+providing approximately 3400 candidates with zero per-keystroke latency.
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-sql-completion_2000x1800.gif?raw=true" align="center" width="100%">
+
+Both uppercase and lowercase variants are generated for SQL keywords, so
+completion works regardless of typing case.
+
+Candidates are annotated with category labels:
+
+| Label     | Meaning                  |
+|-----------+--------------------------|
+| =kw*=     | Reserved SQL keyword     |
+| =kw=      | Unreserved SQL keyword   |
+| =fn=      | Scalar function          |
+| =fn/a=    | Aggregate function       |
+| =fn/m=    | SQL macro                |
+| =fn->T=   | Table-producing function |
+| =fn/m->T= | Table-producing macro    |
+| =pragma=  | Pragma function          |
+| =type=    | Data type                |
+
+Reserved keywords sort before other candidates.
+
+After loading extensions or attaching databases that add new functions or types:
+
+#+begin_src
+M-x duckdb-query-complete-refresh-cache
+#+end_src
+
+To disable SQL metadata completion entirely and keep only reference completion:
+
+#+begin_src emacs-lisp
+(setq duckdb-query-complete-sql-p nil)
+#+end_src
+
+See [[#font-lock-for-reference-syntax][Font Lock for Reference Syntax]] and [[#sql-completion][SQL Completion]] for full documentation.
+
+- Org-Mode Src Blocks ::
+In org-mode, the completion mode narrows to the current =emacs-lisp= or
+=elisp= src block body and switches to ~emacs-lisp-mode-syntax-table~
+before parsing. This ensures correct syntax context and avoids scanning the
+entire org buffer. Completion only activates when point is inside a recognized
+src block.
+
+** Static Analysis Candidates
+
+The completion system also extracts candidates from the SQL string being edited,
+without querying DuckDB:
+
+- CTE names from =WITH name AS= patterns
+- Table aliases from =FROM table alias= and =JOIN table alias= patterns
+- =@data:= binding names as table-like candidates
+
+#+HTML: <img src="https://github.com/gggion/duckdb-query.el/blob/screenshots/duckdb-cte-completion_1920x1080.gif?raw=true" align="center" width="100%">
+
+These candidates sort above DuckDB metadata, so query-specific identifiers
+appear first. They carry their own category labels (=cte=, =alias=, =data=) for
+identification.
 * Acknowledgements
 :PROPERTIES:
 :CUSTOM_ID: acknowledgements
@@ -1054,8 +1543,8 @@ Other benchmark functions: ~duckdb-query-bench-formats~ (compare output formats)
 :END:
 
 #+begin_quote
-[!WARNING]
-UNDER CONSTRUCTION
+[!NOTE]
+The patterns below are stable APIs, but the abstractions built on them are still evolving.
 #+end_quote
 
 As mentioned before, sessions allow low-latency, fast response times, going as

--- a/README.org
+++ b/README.org
@@ -210,12 +210,14 @@ dependencies, and fragment composition with embedded references, see
 - [[#parameterized-queries][Parameterized Queries]]
 - [[#output-formats][Output Formats]]
 - [[#schema-introspection][Schema Introspection]]
+- [[#type-parsing][Type Parsing]]
 - [[#database-persistence][Database Persistence]]
 - [[#session-based-execution][Session-Based Execution]]
 - [[#nested-types][Nested Types]]
 - [[#performance][Performance]]
 - [[#font-lock-for-reference-syntax][Font Lock for Reference Syntax]]
 - [[#sql-completion][SQL Completion]]
+- [[#structural-editing][Structural Editing]]
 - [[#acknowledgements][Acknowledgements]]
 - [[#related-packages][Related Packages]]
 - [[#integration][Integration]]
@@ -1028,6 +1030,106 @@ Discover structure before querying:
 ;;     ((column_name . "name") (column_type . "VARCHAR") (null . "YES") ...))
 #+end_src
 
+~duckdb-query-column-types~ accepts a ~:format~ parameter for structured output.
+See [[#type-parsing][Type Parsing]] for parsed and JSON formats.
+* Type Parsing
+:PROPERTIES:
+:CUSTOM_ID: type-parsing
+:END:
+#+begin_quote
+[!IMPORTANT]
+NEW in 0.8
+#+end_quote
+
+DuckDB's =DESCRIBE= output returns type information as strings. For scalar types
+like ="INTEGER"= this is sufficient, but complex nested types from extensions
+like =webbed= (XML reader) or =spatial= produce opaque strings hundreds of
+characters long. The type parser converts these into structured Elisp:
+
+#+begin_src elisp :results code
+(duckdb-query-parse-type "STRUCT(x INTEGER, y VARCHAR)")
+;; => (STRUCT (x . INTEGER) (y . VARCHAR))
+#+end_src
+
+#+begin_src elisp :results code
+(duckdb-query-parse-type "MAP(VARCHAR, INTEGER[])")
+;; => (MAP VARCHAR (LIST INTEGER))
+#+end_src
+
+#+begin_src elisp :results code
+(duckdb-query-parse-type "STRUCT(a STRUCT(b INTEGER, tags VARCHAR[]))")
+;; => (STRUCT (a . (STRUCT (b . INTEGER) (tags . (LIST VARCHAR)))))
+#+end_src
+
+The parser handles the full DuckDB type system: STRUCT, MAP, LIST, ARRAY, UNION,
+parameterized scalars like =DECIMAL(18,3)=, double-quoted field names, extension
+types, and user-defined types. The representation uses symbols for scalar types
+and nested lists for compound types, making it natural for ~pcase~, ~assq~, and
+recursive traversal.
+
+The ~duckdb-query-column-types~ function accepts a ~:format~ parameter to control
+type representation across an entire schema:
+
+#+begin_src elisp :results code
+;; Raw strings (default, backward compatible)
+(duckdb-query-column-types
+ "SELECT 1 AS id, {'x': 1, 'y': 2}::STRUCT(x INT, y INT) AS point")
+;; => (("id" . "INTEGER") ("point" . "STRUCT(x INTEGER, y INTEGER)"))
+#+end_src
+
+#+begin_src elisp :results code
+;; Parsed Elisp structures
+(duckdb-query-column-types
+ "SELECT 1 AS id, {'x': 1, 'y': 2}::STRUCT(x INT, y INT) AS point"
+ :format :parsed)
+;; => (("id" . INTEGER) ("point" . (STRUCT (x . INTEGER) (y . INTEGER))))
+#+end_src
+
+#+begin_src elisp :results code
+;; JSON schema string
+(duckdb-query-column-types
+ "SELECT 1 AS id, [1,2,3] AS arr"
+ :format :json)
+;; => "[{\"name\":\"id\",\"type\":\"INTEGER\"},{\"name\":\"arr\",\"type\":{\"type\":\"LIST\",\"element\":\"INTEGER\"}}]"
+#+end_src
+
+Individual parsed types can be converted to JSON-serializable structures with
+~duckdb-query-type-to-json~ for integration with external tools or APIs.
+
+The parsed representation enables programmatic schema exploration. For example,
+extracting all field names from a deeply nested STRUCT:
+
+#+begin_src elisp :results code
+(defun my-struct-fields (parsed)
+  "Recursively collect field names from PARSED type."
+  (when (and (listp parsed) (eq (car parsed) 'STRUCT))
+    (let ((fields (cdr parsed)))
+      (append (mapcar (lambda (f) (symbol-name (car f))) fields)
+              (cl-mapcan (lambda (f) (my-struct-fields (cdr f)))
+                         fields)))))
+
+(my-struct-fields
+ (duckdb-query-parse-type
+  "STRUCT(name VARCHAR, address STRUCT(city VARCHAR, zip INTEGER))"))
+;; => ("name" "address" "city" "zip")
+#+end_src
+
+Or pattern matching on column types:
+
+#+begin_src elisp :results code
+(let ((types (duckdb-query-column-types
+              "SELECT 1 AS id, [1,2] AS nums, {'x': 1} AS pt"
+              :format :parsed)))
+  (mapcar (lambda (col)
+            (cons (car col)
+                  (pcase (cdr col)
+                    (`(STRUCT . ,_) "struct")
+                    (`(LIST ,_) "list")
+                    (`(MAP ,_ ,_) "map")
+                    ((pred symbolp) "scalar"))))
+          types))
+;; => (("id" . "scalar") ("nums" . "list") ("pt" . "struct"))
+#+end_src
 * Database Persistence
 :PROPERTIES:
 :CUSTOM_ID: database-persistence
@@ -1518,6 +1620,140 @@ without querying DuckDB:
 These candidates sort above DuckDB metadata, so query-specific identifiers
 appear first. They carry their own category labels (=cte=, =alias=, =data=) for
 identification.
+* Structural Editing
+:PROPERTIES:
+:CUSTOM_ID: structural-editing
+:END:
+#+begin_quote
+[!IMPORTANT]
+NEW in 0.8: Extract, inline, and remove =@type:name= references structurally
+#+end_quote
+
+The =duckdb-query-edit.el= module provides bidirectional structural editing for
+=duckdb-query= forms. As queries grow complex, you progressively decompose
+monolithic SQL strings into composable fragments bound to =:val=, =:sql=, and
+=:data= parameters. The reverse operation supports simplification when references
+are no longer needed.
+
+All commands operate on the enclosing =duckdb-query= form detected via the
+structural parser. No configuration is required beyond loading the module.
+** Extracting to References
+# TODO: add videos to this
+
+Select a region inside a SQL string, then extract it into a named reference with
+the corresponding binding:
+
+#+begin_src elisp
+;; Starting form:
+(duckdb-query
+ "SELECT * FROM read_parquet('https://example.com/data.parquet')
+  WHERE month BETWEEN 6 AND 8")
+
+;; Select the URL, invoke M-x duckdb-query-edit-extract-to-val,
+;; name it "url":
+(duckdb-query
+ "SELECT * FROM read_parquet(@val:url)
+  WHERE month BETWEEN 6 AND 8"
+ :val '((url . "https://example.com/data.parquet")))
+
+;; Then select "month BETWEEN 6 AND 8",
+;; invoke M-x duckdb-query-edit-extract-to-sql, name it "filter":
+(duckdb-query
+ "SELECT * FROM read_parquet(@val:url)
+  WHERE @sql:filter"
+ :val '((url . "https://example.com/data.parquet"))
+ :sql '((filter . "month BETWEEN 6 AND 8")))
+#+end_src
+
+Three pre-typed convenience commands skip the type prompt:
+
+- ~duckdb-query-edit-extract-to-val~: Extract to =:val= parameter
+- ~duckdb-query-edit-extract-to-sql~: Extract to =:sql= parameter
+- ~duckdb-query-edit-extract-to-data~: Extract to =:data= parameter
+
+The general command ~duckdb-query-edit-extract-to-ref~ prompts for both reference
+type and name.
+
+Extraction works inside any string literal in the form, not just the main SQL
+string. This enables progressive decomposition where a fragment extracted from
+the main query can itself be further decomposed from its =:sql= binding value.
+
+** Inlining References
+
+Place point on any =@type:name= reference and invoke
+~duckdb-query-edit-inline-ref~ to replace it with the binding's literal value:
+
+#+begin_src elisp
+;; Point on @sql:filter, invoke M-x duckdb-query-edit-inline-ref:
+;; Before:
+(duckdb-query "SELECT * FROM t WHERE @sql:filter"
+              :sql '((filter . "age > 21")))
+
+;; After (binding preserved):
+(duckdb-query "SELECT * FROM t WHERE age > 21"
+              :sql '((filter . "age > 21")))
+
+;; With C-u prefix, binding is also removed:
+(duckdb-query "SELECT * FROM t WHERE age > 21")
+#+end_src
+
+Without prefix argument, the binding entry is preserved in the parameter alist.
+Orphaned bindings are visible via ~duckdb-query-font-lock-mode~, which highlights
+undefined references. With =C-u= prefix, the binding entry is also removed,
+completing the full round-trip.
+** Removing Bindings
+
+~duckdb-query-edit-remove-binding~ removes the binding entry for the reference at
+point without modifying the reference text. When other references to the same
+binding exist in the form, it prompts for confirmation showing the reference
+count:
+
+#+begin_src elisp
+;; Point on @val:threshold (used twice in the query):
+;; M-x duckdb-query-edit-remove-binding
+;; => "@val:threshold has 2 references; remove binding anyway?"
+#+end_src
+
+~duckdb-query-edit-remove-unused-bindings~ performs bulk cleanup, scanning all
+bindings in the enclosing form and removing those with zero references.
+
+** Value Formatting
+
+Extracted text is formatted appropriately for the target parameter type:
+
+| Target | Input (selected text) | Stored binding value     |
+|--------+-----------------------+--------------------------|
+| =:val=   | ='./data/users.csv'=    | ="./data/users.csv"=       |
+| =:val=   | =42=                    | =42= (numeric, not quoted) |
+| =:sql=   | =month BETWEEN 6 AND 8= | ="month BETWEEN 6 AND 8"=  |
+| =:data=  | (as-is)               | (for manual editing)     |
+
+For =:val=, surrounding SQL single-quotes are stripped because
+~duckdb-query--value-to-sql-literal~ re-adds them at execution time. Numeric
+strings pass through without quoting.
+** Indentation
+
+Post-edit indentation is controlled by ~duckdb-query-edit-indent-after-edit~,
+which defaults to =nil=. When non-nil, ~indent-region~ runs on the enclosing
+=duckdb-query= form after every structural modification. The default respects
+users who rely on ~aggressive-indent-mode~ or other formatting tools:
+
+#+begin_src elisp
+(setq duckdb-query-edit-indent-after-edit t)
+#+end_src
+
+** Command Summary
+
+| Command                                  | Trigger            | Behavior                             |
+|------------------------------------------+--------------------+--------------------------------------|
+| ~duckdb-query-edit-extract-to-ref~         | Region in string   | Prompt type and name, create binding |
+| ~duckdb-query-edit-extract-to-val~         | Region in string   | Create =:val= binding                  |
+| ~duckdb-query-edit-extract-to-sql~         | Region in string   | Create =:sql= binding                  |
+| ~duckdb-query-edit-extract-to-data~        | Region in string   | Create =:data= binding                 |
+| ~duckdb-query-edit-inline-ref~             | Point on reference | Replace ref with value text          |
+| =C-u= ~duckdb-query-edit-inline-ref~         | Point on reference | Replace ref and remove binding       |
+| ~duckdb-query-edit-remove-binding~         | Point on reference | Remove binding, keep reference       |
+| ~duckdb-query-edit-remove-unused-bindings~ | Anywhere in form   | Remove all zero-reference bindings   |
 * Acknowledgements
 :PROPERTIES:
 :CUSTOM_ID: acknowledgements

--- a/README.org
+++ b/README.org
@@ -744,9 +744,12 @@ substitution happens before =:val= processing:
 #+begin_quote
 [!IMPORTANT]
 Variables are /scalar/ values. They must resolve to exactly one column and one
-row. Subqueries returning multiple columns or rows will error:
-=Binder Error: Subquery returns 2 columns - expected 1=.
-For table-valued data, use =@data:= bindings instead.
+row, single value variables are also valid, for example a single url string or a
+number.
+
+Subqueries returning multiple columns or rows will error: =Binder Error:
+Subquery returns 2 columns - expected 1=. For table-valued data, use =@data:=
+bindings instead.
 #+end_quote
 
 ** Query Fragment Composition with =@sql:=

--- a/README.org
+++ b/README.org
@@ -1759,13 +1759,34 @@ users who rely on ~aggressive-indent-mode~ or other formatting tools:
 :CUSTOM_ID: acknowledgements
 :END:
 
-- [[https://github.com/ak-coram/cl-duckdb][cl-duckdb]] by Ákos Kiss: The Common Lisp DuckDB wrapper that inspired this
-  package's design philosophy. The approach of treating query results as native
-  Lisp data structures, the ~with-static-table~ pattern for querying Lisp data
-  directly, and the ~with-transient-connection~ / ~with-default-connection~
-  macros for database context management all informed the design of
-  duckdb-query's ~:data~ parameter, ~@org:~ references, and
-  ~duckdb-query-with-transient-database~ / ~duckdb-query-with-database~ forms.
+Several packages and tools served as reference points for the design and
+implementation of duckdb-query. I would like to credit:
+
+- [[https://github.com/ak-coram/cl-duckdb][cl-duckdb]] by Ákos Kiss: The Common Lisp DuckDB wrapper that inspired treating
+  query results as native Lisp data structures. The =with-static-table= pattern
+  for querying Lisp data directly and the =with-transient-connection= /
+  =with-default-connection= macros for database context management informed the
+  design of =:data=, =@org:= references, =duckdb-query-with-transient-database=, and
+  =duckdb-query-with-database=.
+
+- [[https://github.com/marijnh/Postmodern][Postmodern]] by Marijn Haverbeke: Common Lisp library for PostgreSQL
+  interaction. The database context macros and the =:row=, =:column=, and =:single=
+  output formats introduced in version 0.8 were taken directly from Postmodern's
+  design.
+
+- [[https://github.com/distichum/datagrid][datagrid]] by Joshua Lambert: Emacs package for data manipulation. The decision
+  to add the =:columnar= output format was partly inspired by this package.
+
+- [[https://github.com/tconbeer/harlequin][Harlequin]] by Ted Conbeer: The SQL autocompletion cache and its use of DuckDB
+  meta-functions (=duckdb_functions=, =duckdb_tables=, =duckdb_keywords=,
+  =duckdb_types=) for context-aware completion were inspired by Harlequin's
+  approach.
+
+- Font-lock implementation drew from several packages by Fanael Linithien:
+  [[https://github.com/Fanael/highlight-defined][highlight-defined]], [[https://github.com/Fanael/highlight-numbers][highlight-numbers]], and especially [[https://github.com/Fanael/rainbow-delimiters][rainbow-delimiters]].
+
+- [[https://github.com/abo-abo/lispy][lispy]] by Oleh Krehel: The parser's use of [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Position-Parse.html#index-syntax_002dppss][syntax-ppss]] for structural analysis
+  of Elisp forms was learned from studying lispy's implementation.
 
 * Related Packages
 :PROPERTIES:

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -57,6 +57,23 @@
   :group 'duckdb-query
   :prefix "duckdb-query-complete-")
 
+(defcustom duckdb-query-complete-max-buffer-size nil
+  "Maximum buffer size in bytes for completion activation.
+
+When non-nil and buffer size exceeds this value,
+`duckdb-query-complete-at-point' returns nil immediately.
+
+Protects against performance degradation in large `org-mode' buffers
+where `syntax-ppss' is expensive.
+
+When nil, completion activates regardless of buffer size.
+
+Also see `duckdb-query-font-lock-max-buffer-size'."
+  :type '(choice (const :tag "No limit" nil)
+                 (integer :tag "Maximum bytes"))
+  :group 'duckdb-query-complete
+  :package-version '(duckdb-query . "0.8.0"))
+
 (defcustom duckdb-query-complete-sql-p t
   "Whether to offer SQL autocompletion via DuckDB.
 
@@ -702,155 +719,183 @@ Called by `duckdb-query-complete-at-point'."
   (or (cdr (assoc candidate duckdb-query-complete--type-annotations))
       ""))
 
-;;;; Main capf Entry Point
+;;;; Org Mode Integration
 
+(defun duckdb-query-complete--org-src-block-bounds ()
+  "Return (BEG . END) of elisp src block body at point, or nil.
+
+BEG is position after #+begin_src line.
+END is position of #+end_src line.
+
+Only matches emacs-lisp and elisp src blocks.
+Returns nil if point is not inside such a block."
+  (when (derived-mode-p 'org-mode)
+    (save-excursion
+      (let ((pos (point)))
+        (when (re-search-backward
+               "^[ \t]*#\\+begin_src[ \t]+\\(?:emacs-lisp\\|elisp\\)\\b.*$"
+               nil t)
+          (let ((body-beg (1+ (match-end 0))))
+            (when (re-search-forward
+                   "^[ \t]*#\\+end_src[ \t]*$"
+                   nil t)
+              (let ((body-end (match-beginning 0)))
+                (when (and (<= body-beg pos)
+                           (<= pos body-end))
+                  (cons body-beg body-end))))))))))
+
+(defun duckdb-query-complete--in-org-src-block ()
+  "Attempt completion inside an org elisp src block.
+
+Narrow to the src block body, switch to `emacs-lisp-mode-syntax-table',
+and delegate to the standard completion logic.
+
+Returns capf result or nil."
+  (when-let ((bounds (duckdb-query-complete--org-src-block-bounds)))
+    (let ((block-beg (car bounds))
+          (block-end (cdr bounds)))
+      (save-restriction
+        (narrow-to-region block-beg block-end)
+        (with-syntax-table emacs-lisp-mode-syntax-table
+          ;; Now syntax-ppss and list walking operate on pure Elisp
+          ;; within a small region
+          (when (nth 3 (syntax-ppss))
+            (when-let ((parse-result (duckdb-query--parse-at-point)))
+              (let ((ref-ctx (duckdb-query-complete--ref-context-at-point)))
+                (duckdb-query-complete--dispatch
+                 parse-result ref-ctx)))))))))
+
+;;;; Dispatch Logic
+(defun duckdb-query-complete--dispatch (parse-result ref-ctx)
+  "Dispatch completion based on PARSE-RESULT and REF-CTX.
+
+PARSE-RESULT is a `duckdb-query-parse-result' struct.
+REF-CTX is a reference context plist from
+`duckdb-query-complete--ref-context-at-point', or nil.
+
+Return capf result list or nil.
+
+Called by `duckdb-query-complete-at-point' and
+`duckdb-query-complete--in-org-src-block'."
+  (duckdb-query-complete--debug-log "dispatch ref-ctx=%S" ref-ctx)
+  (if ref-ctx
+      ;; Reference completion branch
+      (let ((context (plist-get ref-ctx :context)))
+        (pcase context
+          ;; Context 1: @type:name -- complete binding names
+          (:type-name
+           (let ((type-str (plist-get ref-ctx :type))
+                 (name-start (plist-get ref-ctx :name-start))
+                 (at-pos (plist-get ref-ctx :at-pos)))
+             (when (duckdb-query-complete--in-completable-string-p
+                    parse-result at-pos)
+               (let ((candidates
+                      (duckdb-query-complete--binding-candidates
+                       parse-result type-str)))
+                 (duckdb-query-complete--debug-log
+                  "ref @%s: candidates=%S" type-str candidates)
+                 (when candidates
+                   (let ((definitions
+                          (duckdb-query-complete--binding-definitions
+                           parse-result type-str)))
+                     (list name-start (point) candidates
+                           :exclusive t
+                           :company-prefix-length t
+                           :affixation-function
+                           (duckdb-query-complete--name-affixation
+                            type-str definitions))))))))
+          ;; Context 2: @type-prefix -- complete type names
+          (:type-prefix
+           (let ((type-start (plist-get ref-ctx :type-start))
+                 (at-pos (plist-get ref-ctx :at-pos)))
+             (when (duckdb-query-complete--in-completable-string-p
+                    parse-result at-pos)
+               (duckdb-query-complete--debug-log "type-prefix completion")
+               (list type-start (point)
+                     duckdb-query-complete--type-candidates
+                     :exclusive t
+                     :company-prefix-length t
+                     :annotation-function
+                     #'duckdb-query-complete--type-annotation))))))
+    ;; SQL completion branch
+    (when duckdb-query-complete-sql-p
+      (let* ((sql-beg (duckdb-query-parse-result-sql-beg
+                       parse-result))
+             (sql-end (duckdb-query-parse-result-sql-end
+                       parse-result)))
+        ;; Only complete in main SQL string
+        (when (and sql-beg sql-end
+                   (> (point) sql-beg)
+                   (< (point) sql-end))
+          (let* ((cached (duckdb-query-complete--cached-sql-candidates))
+                 (static (duckdb-query-complete--static-candidates
+                          parse-result))
+                 (candidates (if static
+                                 (append static cached)
+                               cached)))
+            (when candidates
+              (let ((word-start
+                     (save-excursion
+                       (skip-chars-backward "a-zA-Z0-9_.")
+                       (point))))
+                (duckdb-query-complete--debug-log
+                 "SQL cache: %d cached + %d static, start=%d end=%d"
+                 (length (or cached '()))
+                 (length (or static '()))
+                 word-start (point))
+                (list word-start (point) candidates
+                      :exclusive 'no
+                      :company-prefix-length t
+                      :annotation-function
+                      #'duckdb-query-complete--sql-annotation
+                      :display-sort-function
+                      #'duckdb-query-complete--sql-sort)))))))))
+
+;;;; Main capf Entry Point
 (defun duckdb-query-complete-at-point ()
   "Completion-at-point function for `duckdb-query' SQL strings.
 
 Return nil when point is not in a completable context.
 Return (START END COLLECTION . PROPS) for active completion.
 
+In `emacs-lisp-mode', detect string context via `syntax-ppss'
+and parse the enclosing `duckdb-query' form.
+
+In `org-mode', narrow to the current elisp src block body and
+switch to `emacs-lisp-mode-syntax-table' before parsing.  This
+avoids scanning the entire org buffer and ensures correct syntax
+context for list walking and `syntax-ppss'.
+
+Skip entirely when buffer size exceeds
+`duckdb-query-complete-max-buffer-size'.
+
 Completion contexts, checked in order:
 
   @type:partial-name  Complete binding names for that type.
   @partial-type       Complete reference type prefixes.
-  plain SQL text      Complete SQL keywords, functions, types from cache.
-
-Completable string positions:
-- Main SQL string argument to `duckdb-query' family functions
-- String literals inside :val, :sql, and :data parameter values
-
-Fast rejection path:
-1. Not inside a string -- return nil immediately.
-2. Not inside a `duckdb-query' family form -- return nil.
-
-For reference contexts:
-3. At an @ reference trigger -- return binding candidates.
-4. @ position not in a completable string -- return nil.
-
-For SQL completion (when `duckdb-query-complete-sql-p' is non-nil):
-5. Serve cached candidates from `duckdb-query-complete--sql-candidates'.
-6. Merge with static analysis candidates (CTEs, aliases, data bindings).
-7. Use backward word scan from point for START position.
-
-Reference completion uses :exclusive t to prevent other capf
-functions (notably `cape-dabbrev') from providing conflicting
-candidates when inside a recognized @type:name context.
-
-SQL completion uses :exclusive no to allow fallback when cache
-is empty or DuckDB was unavailable at mode enable.
-
-Both branches use :company-prefix-length t to force corfu
-auto-completion regardless of `corfu-auto-prefix' threshold.
-
-Name candidates display binding definitions via
-:affixation-function.  Each candidate shows the value expression
-from the corresponding parameter binding.
-
-SQL candidates are annotated with category labels (kw*, fn, fn/a,
-fn->T, type, etc.) from cached DuckDB metadata.  Static analysis
-candidates (CTEs, aliases, data bindings) sort before DuckDB
-metadata via priority 50 < 100.
-
-When `duckdb-query-complete--debug' is non-nil, all capf calls,
-candidate counts, and errors are logged to the
-*duckdb-complete-debug* buffer.
-
-When this function returns nil (not in a completable context),
-other capf functions run normally.
+  plain SQL text      Complete SQL keywords, functions, types.
 
 Install via `duckdb-query-complete-mode' or manually:
 
   (add-hook \\='completion-at-point-functions
             #\\='duckdb-query-complete-at-point -90 t)
 
-Uses `duckdb-query-complete--ref-context-at-point' for trigger detection.
-Uses `duckdb-query--parse-at-point' for structural analysis.
-Uses `duckdb-query-complete--in-completable-string-p' for boundary check.
-Uses `duckdb-query-complete--binding-candidates' for candidate extraction.
-Uses `duckdb-query-complete--binding-definitions' for value display.
-Uses `duckdb-query-complete--cached-sql-candidates' for SQL candidates.
-Uses `duckdb-query-complete--static-candidates' for parser-derived candidates.
+Uses `duckdb-query-complete--dispatch' for candidate generation.
+Uses `duckdb-query-complete--in-org-src-block' for `org-mode' context.
 Also see `duckdb-query-complete-toggle-debug' for debug logging."
   (duckdb-query-complete--debug-log "capf called at point=%d" (point))
-  ;; Fast rejection: must be inside a string
-  (when (nth 3 (syntax-ppss))
-    ;; Must be inside a duckdb-query family form
-    (when-let* ((parse-result (duckdb-query--parse-at-point)))
-      (let ((ref-ctx (duckdb-query-complete--ref-context-at-point)))
-        (duckdb-query-complete--debug-log "ref-ctx=%S" ref-ctx)
-        (if ref-ctx
-            ;; Reference completion branch
-            (let ((context (plist-get ref-ctx :context)))
-              (pcase context
-                ;; Context 1: @type:name -- complete binding names
-                (:type-name
-                 (let ((type-str (plist-get ref-ctx :type))
-                       (name-start (plist-get ref-ctx :name-start))
-                       (at-pos (plist-get ref-ctx :at-pos)))
-                   (when (duckdb-query-complete--in-completable-string-p
-                          parse-result at-pos)
-                     (let ((candidates
-                            (duckdb-query-complete--binding-candidates
-                             parse-result type-str)))
-                       (duckdb-query-complete--debug-log
-                        "ref @%s: candidates=%S" type-str candidates)
-                       (when candidates
-                         (let ((definitions
-                                (duckdb-query-complete--binding-definitions
-                                 parse-result type-str)))
-                           (list name-start (point) candidates
-                                 :exclusive t
-                                 :company-prefix-length t
-                                 :affixation-function
-                                 (duckdb-query-complete--name-affixation
-                                  type-str definitions))))))))
-                ;; Context 2: @type-prefix -- complete type names
-                (:type-prefix
-                 (let ((type-start (plist-get ref-ctx :type-start))
-                       (at-pos (plist-get ref-ctx :at-pos)))
-                   (when (duckdb-query-complete--in-completable-string-p
-                          parse-result at-pos)
-                     (duckdb-query-complete--debug-log "type-prefix completion")
-                     (list type-start (point)
-                           duckdb-query-complete--type-candidates
-                           :exclusive t
-                           :company-prefix-length t
-                           :annotation-function
-                           #'duckdb-query-complete--type-annotation))))))
-          ;; SQL completion branch
-          (when duckdb-query-complete-sql-p
-            (let* ((sql-beg (duckdb-query-parse-result-sql-beg
-                             parse-result))
-                   (sql-end (duckdb-query-parse-result-sql-end
-                             parse-result)))
-              ;; Only complete in main SQL string
-              (when (and sql-beg sql-end
-                         (> (point) sql-beg)
-                         (< (point) sql-end))
-                (let* ((cached (duckdb-query-complete--cached-sql-candidates))
-                       (static (duckdb-query-complete--static-candidates
-                                parse-result))
-                       (candidates (if static
-                                       (append static cached)
-                                     cached)))
-                  (when candidates
-                    (let ((word-start
-                           (save-excursion
-                             (skip-chars-backward "a-zA-Z0-9_.")
-                             (point))))
-                      (duckdb-query-complete--debug-log
-                       "SQL cache: %d cached + %d static, start=%d end=%d"
-                       (length (or cached '()))
-                       (length (or static '()))
-                       word-start (point))
-                      (list word-start (point) candidates
-                            :exclusive 'no
-                            :company-prefix-length t
-                            :annotation-function
-                            #'duckdb-query-complete--sql-annotation
-                            :display-sort-function
-                            #'duckdb-query-complete--sql-sort))))))))))))
+  ;; Buffer size guard
+  (when (or (null duckdb-query-complete-max-buffer-size)
+            (<= (buffer-size) duckdb-query-complete-max-buffer-size))
+    (cond
+     ;; Org-mode: narrow to src block, use elisp syntax table
+     ((derived-mode-p 'org-mode)
+      (duckdb-query-complete--in-org-src-block))
+     ;; Emacs-lisp-mode: standard path
+     ((nth 3 (syntax-ppss))
+      (when-let ((parse-result (duckdb-query--parse-at-point)))
+        (let ((ref-ctx (duckdb-query-complete--ref-context-at-point)))
+          (duckdb-query-complete--dispatch parse-result ref-ctx)))))))
 
 ;;;; Minor Mode
 

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -258,9 +258,17 @@ Fast rejection path:
 3. Not at an @ reference trigger -- return nil.
 4. @ position not in a completable string -- return nil.
 
-Coexists with `elisp-completion-at-point' via :exclusive property
-set to \\='no, allowing fallback to other capf functions when this
-function has no applicable candidates.
+Reference completion uses :exclusive t to prevent other capf
+functions (notably `cape-dabbrev') from providing conflicting
+candidates when inside a recognized @type:name context.
+
+Uses :company-prefix-length t to force corfu auto-completion
+regardless of `corfu-auto-prefix' threshold.  Without this,
+corfu ignores our candidates when the completion region (text
+after the colon) is shorter than `corfu-auto-prefix'.
+
+When this function returns nil (not in a completable context),
+other capf functions run normally.
 
 Install via `duckdb-query-complete-mode' or manually:
 
@@ -289,7 +297,8 @@ Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
                                   parse-result type-str)))
                  (when candidates
                    (list name-start (point) candidates
-                         :exclusive 'no
+                         :exclusive t
+                         :company-prefix-length t
                          :annotation-function
                          (duckdb-query-complete--name-annotation
                           type-str)))))))
@@ -301,7 +310,8 @@ Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
                     parse-result at-pos)
                (list type-start (point)
                      duckdb-query-complete--type-candidates
-                     :exclusive 'no
+                     :exclusive t
+                     :company-prefix-length t
                      :annotation-function
                      #'duckdb-query-complete--type-annotation)))))))))
 

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -191,6 +191,103 @@ Called by `duckdb-query-complete-at-point'."
 
 ;;;; Candidate Generation
 
+(defun duckdb-query-complete--extract-binding-definitions (val-beg val-end)
+  "Extract binding name-to-definition alist from parameter value.
+
+VAL-BEG and VAL-END delimit the parameter value region.
+
+Walk the alist structure, extracting each binding's name symbol
+and the text representation of its value (the cdr of each cons cell).
+
+Return alist of (NAME-STRING . DEFINITION-STRING) pairs.
+Return nil if the region does not contain a valid binding list.
+
+Handles quoted and backquoted forms.  Skips unquote markers
+(comma and comma-at).  Recognizes cons pairs by the dot separator
+after the car symbol.
+
+Example for :val \\='((min_price . 25) (avg_revenue . (sql \"...\"))):
+
+  ((\"min_price\" . \"25\")
+   (\"avg_revenue\" . \"(sql \\\"...\\\")\"))
+
+Called by `duckdb-query-complete--binding-definitions'.
+Uses the same structural walking strategy as
+`duckdb-query--extract-binding-names'."
+  (save-excursion
+    (goto-char val-beg)
+    (duckdb-query--skip-whitespace-and-comments)
+    ;; Skip quote or backquote
+    (when (memq (char-after) (list duckdb-query--char-quote
+                                   duckdb-query--char-backquote))
+      (forward-char 1))
+    (let (definitions)
+      (when (eq (char-after) duckdb-query--char-lparen)
+        (let ((list-end (save-excursion
+                          (when (duckdb-query--forward-sexp-safe)
+                            (1- (point))))))
+          (when (and list-end (< list-end val-end))
+            (forward-char 1) ;; enter outer list
+            (while (< (point) list-end)
+              (duckdb-query--skip-whitespace-and-comments)
+              ;; Skip unquote markers
+              (when (eq (char-after) duckdb-query--char-comma)
+                (forward-char 1)
+                (when (eq (char-after) duckdb-query--char-at)
+                  (forward-char 1)))
+              (duckdb-query--skip-whitespace-and-comments)
+              (when (and (< (point) list-end)
+                         (eq (char-after) duckdb-query--char-lparen))
+                (let ((pair-start (point)))
+                  (forward-char 1) ;; enter cons cell
+                  (duckdb-query--skip-whitespace-and-comments)
+                  (when (looking-at "\\([a-zA-Z_][a-zA-Z0-9_-]*\\)")
+                    (let ((name (match-string-no-properties 1)))
+                      (goto-char (match-end 0))
+                      (duckdb-query--skip-whitespace-and-comments)
+                      (when (eq (char-after) duckdb-query--char-dot)
+                        (forward-char 1) ;; skip dot
+                        (duckdb-query--skip-whitespace-and-comments)
+                        ;; Skip unquote marker before value
+                        (when (eq (char-after) duckdb-query--char-comma)
+                          (forward-char 1)
+                          (when (eq (char-after) duckdb-query--char-at)
+                            (forward-char 1)))
+                        (duckdb-query--skip-whitespace-and-comments)
+                        (let ((val-start (point)))
+                          (when (duckdb-query--forward-sexp-safe)
+                            (let ((val-text
+                                   (string-trim
+                                    (buffer-substring-no-properties
+                                     val-start (point)))))
+                              (push (cons name val-text)
+                                    definitions)))))))
+                  (goto-char pair-start)))
+              (unless (duckdb-query--forward-sexp-safe)
+                (forward-char 1))))))
+      (nreverse definitions))))
+
+(defun duckdb-query-complete--binding-definitions (parse-result type-str)
+  "Return alist of (NAME . DEFINITION) for TYPE-STR from PARSE-RESULT.
+
+PARSE-RESULT is a `duckdb-query-parse-result' struct.
+TYPE-STR is one of \"sql\", \"data\", \"val\".
+
+Return alist of (NAME-STRING . DEFINITION-STRING) pairs, or nil
+if no bindings exist for that type.
+
+Uses `duckdb-query-complete--extract-binding-definitions' to walk
+the parameter value region.
+
+Called by `duckdb-query-complete-at-point' for affixation."
+  (let ((keyword (intern (format ":%s" type-str))))
+    (cl-some (lambda (param)
+               (when (eq (plist-get param :key) keyword)
+                 (duckdb-query-complete--extract-binding-definitions
+                  (plist-get param :val-beg)
+                  (plist-get param :val-end))))
+             (duckdb-query-parse-result-params parse-result))))
+
 (defun duckdb-query-complete--binding-candidates (parse-result type-str)
   "Return binding name strings for TYPE-STR from PARSE-RESULT.
 
@@ -212,16 +309,28 @@ Uses `duckdb-query-parse-result-bindings' for data access."
 
 ;;;; Annotation Functions
 
-(defun duckdb-query-complete--name-annotation (type-str)
-  "Return annotation function for binding name candidates.
+(defun duckdb-query-complete--name-affixation (type-str definitions)
+  "Return affixation function for binding name candidates.
 
-TYPE-STR is the reference type string (\"sql\", \"data\", \"val\").
+TYPE-STR is the reference type (\"sql\", \"data\", \"val\").
+DEFINITIONS is alist of (NAME . DEFINITION-TEXT) pairs.
 
-Return function suitable for :annotation-function property.
+Return function suitable for :affixation-function property.
+Each candidate is displayed as:
+
+  candidate-name  definition-text  @type
 
 Called by `duckdb-query-complete-at-point'."
-  (let ((suffix (format " @%s" type-str)))
-    (lambda (_candidate) suffix)))
+  (let ((type-suffix (format " @%s" type-str)))
+    (lambda (candidates)
+      (mapcar (lambda (cand)
+                (let ((def (or (cdr (assoc cand definitions)) "")))
+                  ;; Truncate long definitions
+                  (when (> (length def) 60)
+                    (setq def (concat (substring def 0 57) "...")))
+                  (list cand "" (propertize (format " %s %s" def type-suffix)
+                                            'face 'completions-annotations))))
+              candidates))))
 
 (defun duckdb-query-complete--type-annotation (candidate)
   "Return annotation for type CANDIDATE.
@@ -267,6 +376,10 @@ regardless of `corfu-auto-prefix' threshold.  Without this,
 corfu ignores our candidates when the completion region (text
 after the colon) is shorter than `corfu-auto-prefix'.
 
+Name candidates display binding definitions via
+:affixation-function.  Each candidate shows the value expression
+from the corresponding parameter binding.
+
 When this function returns nil (not in a completable context),
 other capf functions run normally.
 
@@ -278,7 +391,8 @@ Install via `duckdb-query-complete-mode' or manually:
 Uses `duckdb-query-complete--ref-context-at-point' for trigger detection.
 Uses `duckdb-query--parse-at-point' for structural analysis.
 Uses `duckdb-query-complete--in-completable-string-p' for boundary check.
-Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
+Uses `duckdb-query-complete--binding-candidates' for candidate extraction.
+Uses `duckdb-query-complete--binding-definitions' for value display."
   ;; Fast rejection: must be inside a string
   (when (nth 3 (syntax-ppss))
     ;; Must be inside a duckdb-query family form
@@ -296,12 +410,15 @@ Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
                (let ((candidates (duckdb-query-complete--binding-candidates
                                   parse-result type-str)))
                  (when candidates
-                   (list name-start (point) candidates
-                         :exclusive t
-                         :company-prefix-length t
-                         :annotation-function
-                         (duckdb-query-complete--name-annotation
-                          type-str)))))))
+                   (let ((definitions
+                          (duckdb-query-complete--binding-definitions
+                           parse-result type-str)))
+                     (list name-start (point) candidates
+                           :exclusive t
+                           :company-prefix-length t
+                           :affixation-function
+                           (duckdb-query-complete--name-affixation
+                            type-str definitions))))))))
           ;; Context 2: @type-prefix -- complete type names
           (:type-prefix
            (let ((type-start (plist-get ref-ctx :type-start))

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -29,21 +29,25 @@
 ;;
 ;;     (add-hook 'emacs-lisp-mode-hook #'duckdb-query-complete-mode)
 ;;
-;; Provides completion for @type:name references inside SQL string
-;; arguments to `duckdb-query' and related functions.  Candidates
-;; are extracted from the :sql, :data, and :val keyword parameters
-;; via structural parsing.
+;; Provides two completion contexts inside SQL string arguments to
+;; `duckdb-query' and related functions:
 ;;
-;; Completion triggers:
+;; Reference completion (@type:name):
 ;; - @val:   Complete binding names from :val parameter
 ;; - @data:  Complete binding names from :data parameter
 ;; - @sql:   Complete binding names from :sql parameter
 ;; - @org:   No candidates (org tables resolved externally)
 ;; - @       Complete reference type prefixes
 ;;
+;; SQL completion (keywords, functions, types):
+;; - Populated from DuckDB metadata on mode enable
+;; - Serves ~3400 candidates from buffer-local cache
+;; - Enriched with CTE names, table aliases, @data: bindings
+;; - Controlled by `duckdb-query-complete-sql-p'
+;; - Idle trigger controlled by `duckdb-query-complete-trigger'
+;;
 ;; Uses `duckdb-query-parse.el' for structural analysis.
 ;; Coexists with `elisp-completion-at-point' via :exclusive property.
-
 ;;; Code:
 
 (require 'cl-lib)

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -156,24 +156,38 @@ Also see `duckdb-query-complete--type-strings' for valid types."
 
 ;;;; Boundary Validation
 
-(defun duckdb-query-complete--in-sql-string-p (parse-result at-pos)
-  "Return non-nil if AT-POS is within the main SQL string.
+(defun duckdb-query-complete--in-completable-string-p (parse-result at-pos)
+  "Return non-nil if AT-POS is in a completable string context.
 
 PARSE-RESULT is a `duckdb-query-parse-result' struct.
 AT-POS is the buffer position of the @ character.
 
-Returns non-nil when AT-POS falls between the opening and closing
-quotes of the main SQL string argument.
+Completable contexts:
+- Main SQL string argument (between sql-beg and sql-end)
+- String literals inside :val, :sql, or :data parameter values
 
-Does not validate positions inside parameter value strings.
-Phase 1 restricts completion to the main SQL string only.
+Return non-nil when AT-POS falls within any of these regions.
+
+Provides broader context coverage.
 
 Called by `duckdb-query-complete-at-point'."
   (let ((sql-beg (duckdb-query-parse-result-sql-beg parse-result))
         (sql-end (duckdb-query-parse-result-sql-end parse-result)))
-    (and sql-beg sql-end
-         (> at-pos sql-beg)
-         (< at-pos sql-end))))
+    (or
+     ;; Main SQL string
+     (and sql-beg sql-end
+          (> at-pos sql-beg)
+          (< at-pos sql-end))
+     ;; Parameter value strings
+     (cl-some
+      (lambda (param)
+        (let ((key (plist-get param :key)))
+          (when (memq key '(:val :sql :data))
+            (let ((val-beg (plist-get param :val-beg))
+                  (val-end (plist-get param :val-end)))
+              (and (> at-pos val-beg)
+                   (< at-pos val-end))))))
+      (duckdb-query-parse-result-params parse-result)))))
 
 ;;;; Candidate Generation
 
@@ -234,10 +248,15 @@ Completion contexts:
   @type:partial-name  Complete binding names for that type.
   @partial-type       Complete reference type prefixes.
 
+Completable string positions:
+- Main SQL string argument to `duckdb-query' family functions
+- String literals inside :val, :sql, and :data parameter values
+
 Fast rejection path:
 1. Not inside a string -- return nil immediately.
 2. Not inside a `duckdb-query' family form -- return nil.
 3. Not at an @ reference trigger -- return nil.
+4. @ position not in a completable string -- return nil.
 
 Coexists with `elisp-completion-at-point' via :exclusive property
 set to \\='no, allowing fallback to other capf functions when this
@@ -250,6 +269,7 @@ Install via `duckdb-query-complete-mode' or manually:
 
 Uses `duckdb-query-complete--ref-context-at-point' for trigger detection.
 Uses `duckdb-query--parse-at-point' for structural analysis.
+Uses `duckdb-query-complete--in-completable-string-p' for boundary check.
 Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
   ;; Fast rejection: must be inside a string
   (when (nth 3 (syntax-ppss))
@@ -263,7 +283,7 @@ Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
            (let ((type-str (plist-get ref-ctx :type))
                  (name-start (plist-get ref-ctx :name-start))
                  (at-pos (plist-get ref-ctx :at-pos)))
-             (when (duckdb-query-complete--in-sql-string-p
+             (when (duckdb-query-complete--in-completable-string-p
                     parse-result at-pos)
                (let ((candidates (duckdb-query-complete--binding-candidates
                                   parse-result type-str)))
@@ -277,7 +297,7 @@ Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
           (:type-prefix
            (let ((type-start (plist-get ref-ctx :type-start))
                  (at-pos (plist-get ref-ctx :at-pos)))
-             (when (duckdb-query-complete--in-sql-string-p
+             (when (duckdb-query-complete--in-completable-string-p
                     parse-result at-pos)
                (list type-start (point)
                      duckdb-query-complete--type-candidates

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -98,9 +98,6 @@ Also see `duckdb-query-complete-sql-p'."
   :package-version '(duckdb-query . "0.8.0"))
 
 ;;;; Internal Variables
-(defconst duckdb-query-complete--sql-annotation " 🦆"
-  "Annotation suffix for SQL autocompletion candidates.")
-
 (defconst duckdb-query-complete--cache-query
   "SELECT label, type_label, priority FROM (
   SELECT DISTINCT keyword_name AS label,
@@ -381,6 +378,54 @@ Also see `duckdb-query-complete--populate-cache'."
              (length duckdb-query-complete--sql-candidates))))
 
 ;;;; SQL Autocompletion
+(defun duckdb-query-complete--sql-annotation (candidate)
+  "Return annotation for SQL CANDIDATE from cached metadata.
+
+Read `duckdb-query--type-label' text property and format as
+right-aligned category label.
+
+Return \" kw*\" for reserved keywords, \" fn\" for scalar
+functions, \" agg\" for aggregates, etc.
+
+Falls back to duck emoji when candidate has no type property
+\(live mode candidates).
+
+Called as :annotation-function in SQL completion branch."
+  (let ((type-label (get-text-property 0 'duckdb-query--type-label
+                                       candidate)))
+    (if type-label
+        (format " %s" type-label)
+      " ddb")))
+
+(defun duckdb-query-complete--sql-sort (candidates)
+  "Sort CANDIDATES by priority then alphabetically.
+
+Read `duckdb-query--priority' text property from each candidate.
+Lower priority values sort first (reserved keywords before functions).
+Candidates without priority sort last.
+
+Called as :display-sort-function in SQL completion branch."
+  (sort (copy-sequence candidates)
+        (lambda (a b)
+          (let ((pa (or (get-text-property 0 'duckdb-query--priority a) 9999))
+                (pb (or (get-text-property 0 'duckdb-query--priority b) 9999)))
+            (if (= pa pb)
+                (string< a b)
+              (< pa pb))))))
+
+(defun duckdb-query-complete--cached-sql-candidates ()
+  "Return cached SQL candidate list, populating if needed.
+
+If cache is nil, attempt population.  If cache is `empty' or
+population fails, return nil.
+
+Return `duckdb-query-complete--sql-candidates' list.
+
+Called by `duckdb-query-complete-at-point' in :cache mode."
+  (when (null duckdb-query-complete--sql-cache)
+    (duckdb-query-complete--populate-cache))
+  (unless (eq duckdb-query-complete--sql-cache 'empty)
+    duckdb-query-complete--sql-candidates))
 
 (defun duckdb-query-complete--sanitize-for-autocomplete (sql parse-result)
   "Replace @type:name references in SQL with parseable substitutions.
@@ -756,9 +801,7 @@ Also see `duckdb-query-complete-toggle-debug' for debug logging."
                            #'duckdb-query-complete--type-annotation))))))
           ;; SQL completion branch
           (when duckdb-query-complete-sql-p
-            (let* ((str-start (nth 8 (syntax-ppss)))
-                   (content-start (1+ str-start))
-                   (sql-beg (duckdb-query-parse-result-sql-beg
+            (let* ((sql-beg (duckdb-query-parse-result-sql-beg
                              parse-result))
                    (sql-end (duckdb-query-parse-result-sql-end
                              parse-result)))
@@ -766,36 +809,55 @@ Also see `duckdb-query-complete-toggle-debug' for debug logging."
               (when (and sql-beg sql-end
                          (> (point) sql-beg)
                          (< (point) sql-end))
-                (let* ((partial-sql
-                        (buffer-substring-no-properties
-                         content-start (point)))
-                       (sanitized-sql
-                        (duckdb-query-complete--sanitize-for-autocomplete
-                         partial-sql parse-result))
-                       (raw-results
-                        (duckdb-query-complete--sql-candidates
-                         sanitized-sql)))
-                  (if raw-results
-                      (let* ((word-start
+                (pcase duckdb-query-complete-sql-source
+                  ;; Cached mode: serve from buffer-local list
+                  (:cache
+                   (let ((candidates (duckdb-query-complete--cached-sql-candidates)))
+                     (when candidates
+                       (let ((word-start
                               (save-excursion
                                 (skip-chars-backward "a-zA-Z0-9_.")
-                                (point)))
-                             (candidates
-                              (mapcar (lambda (row)
-                                        (cdr (assq 'suggestion row)))
-                                      raw-results)))
-                        (duckdb-query-complete--debug-log
-                         "SQL returning %d candidates, start=%d end=%d"
-                         (length candidates) word-start (point))
-                        (list word-start (point) candidates
-                              :exclusive 'no
-                              :company-prefix-length t
-                              :annotation-function
-                              (lambda (_)
-                                duckdb-query-complete--sql-annotation)))
-                    (duckdb-query-complete--debug-log
-                     "SQL branch: no results from DuckDB")
-                    nil))))))))))
+                                (point))))
+                         (duckdb-query-complete--debug-log
+                          "SQL cache: %d candidates, start=%d end=%d"
+                          (length candidates) word-start (point))
+                         (list word-start (point) candidates
+                               :exclusive 'no
+                               :company-prefix-length t
+                               :annotation-function
+                               #'duckdb-query-complete--sql-annotation
+                               :display-sort-function
+                               #'duckdb-query-complete--sql-sort)))))
+                  ;; Live mode: query sql_auto_complete per request
+                  (:live
+                   (let* ((str-start (nth 8 (syntax-ppss)))
+                          (content-start (1+ str-start))
+                          (partial-sql
+                           (buffer-substring-no-properties
+                            content-start (point)))
+                          (sanitized-sql
+                           (duckdb-query-complete--sanitize-for-autocomplete
+                            partial-sql parse-result))
+                          (raw-results
+                           (duckdb-query-complete--sql-candidates
+                            sanitized-sql)))
+                     (when raw-results
+                       (let* ((word-start
+                               (save-excursion
+                                 (skip-chars-backward "a-zA-Z0-9_.")
+                                 (point)))
+                              (candidates
+                               (mapcar (lambda (row)
+                                         (cdr (assq 'suggestion row)))
+                                       raw-results)))
+                         (duckdb-query-complete--debug-log
+                          "SQL live: %d candidates, start=%d end=%d"
+                          (length candidates) word-start (point))
+                         (list word-start (point) candidates
+                               :exclusive 'no
+                               :company-prefix-length t
+                               :annotation-function
+                               (lambda (_) " ddb")))))))))))))))
 
 ;;;; Minor Mode
 

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -1,0 +1,319 @@
+;;; duckdb-query-complete.el --- Completion for duckdb-query forms -*- lexical-binding: t; -*-
+;;
+;; Author: Gino Cornejo <gggion123@gmail.com>
+;; Maintainer: Gino Cornejo <gggion123@gmail.com>
+;; Homepage: https://github.com/gggion/duckdb-query.el
+
+;; This file is part of duckdb-query.
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Completion-at-point support for `duckdb-query' SQL strings.
+;;
+;; Basic usage:
+;;
+;;     (add-hook 'emacs-lisp-mode-hook #'duckdb-query-complete-mode)
+;;
+;; Provides completion for @type:name references inside SQL string
+;; arguments to `duckdb-query' and related functions.  Candidates
+;; are extracted from the :sql, :data, and :val keyword parameters
+;; via structural parsing.
+;;
+;; Completion triggers:
+;; - @val:   Complete binding names from :val parameter
+;; - @data:  Complete binding names from :data parameter
+;; - @sql:   Complete binding names from :sql parameter
+;; - @org:   No candidates (org tables resolved externally)
+;; - @       Complete reference type prefixes
+;;
+;; Uses `duckdb-query-parse.el' for structural analysis.
+;; Coexists with `elisp-completion-at-point' via :exclusive property.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'duckdb-query-parse)
+
+;;;; Customization
+
+(defgroup duckdb-query-complete nil
+  "Completion support for `duckdb-query' SQL strings."
+  :group 'duckdb-query
+  :prefix "duckdb-query-complete-")
+
+;;;; Reference Type Constants
+
+(defconst duckdb-query-complete--type-strings '("sql" "data" "val" "org")
+  "Valid reference type strings for @type:name references.")
+
+(defconst duckdb-query-complete--type-candidates '("sql:" "data:" "val:" "org:")
+  "Completion candidates for type selection after @ trigger.
+
+Each candidate includes the trailing colon so cursor lands
+immediately at the name position after completion.")
+
+(defconst duckdb-query-complete--type-annotations
+  '(("sql:"  . " SQL fragment")
+    ("data:" . " Elisp data")
+    ("val:"  . " literal value")
+    ("org:"  . " Org table"))
+  "Alist mapping type candidates to annotation strings.
+
+Used by `duckdb-query-complete--type-annotation'.")
+
+;;;; Context Detection
+
+(defun duckdb-query-complete--ref-context-at-point ()
+  "Detect @type:name reference context at point.
+
+Return plist describing the completion context, or nil if point
+is not at a reference trigger position.
+
+Caller must verify point is inside a string within a recognized
+`duckdb-query' form before calling this function.
+
+Uses two-phase backward character scan:
+1. Scan backward over name characters (a-z, A-Z, 0-9, _)
+2. If preceded by colon, scan backward over type characters
+3. If preceded by @, validate type against known types
+
+Return plist with :context key indicating completion mode:
+
+  (:context :type-name
+   :type \"val\"
+   :name-start 25
+   :at-pos 20)
+
+  (:context :type-prefix
+   :type-start 21
+   :at-pos 20)
+
+  nil -- point is not at a reference trigger
+
+Called by `duckdb-query-complete-at-point'.
+Also see `duckdb-query-complete--type-strings' for valid types."
+  (save-excursion
+    (let ((end (point))
+          name-start colon-pos type-start at-pos type-str)
+      (skip-chars-backward "a-zA-Z0-9_")
+      (setq name-start (point))
+      (cond
+       ;; Case 1: preceded by colon -- @type:name| context
+       ((and (eq (char-before) ?:)
+             (progn
+               (setq colon-pos (1- (point)))
+               (goto-char colon-pos)
+               (skip-chars-backward "a-zA-Z")
+               (setq type-start (point))
+               (and (eq (char-before) ?@)
+                    (setq at-pos (1- (point)))
+                    (setq type-str (buffer-substring-no-properties
+                                    type-start colon-pos))
+                    (member type-str duckdb-query-complete--type-strings))))
+        (list :context :type-name
+              :type type-str
+              :name-start name-start
+              :at-pos at-pos))
+       ;; Case 2: preceded by @ -- @type-prefix| context
+       ((and (eq (char-before (point)) ?@)
+             ;; Ensure name-start equals current point (no colon found)
+             (= name-start (point))
+             (setq at-pos (1- (point))))
+        ;; Re-scan: name chars after @ with no colon
+        (goto-char end)
+        (skip-chars-backward "a-zA-Z0-9_")
+        ;; Check if the character before the scan result is @
+        (when (eq (char-before) ?@)
+          (list :context :type-prefix
+                :type-start (point)
+                :at-pos (1- (point)))))
+       ;; Case 2b: @ followed by partial type text
+       ((progn
+          (goto-char name-start)
+          (and (> (- end name-start) 0)
+               (eq (char-before) ?@)
+               (setq at-pos (1- (point)))))
+        (list :context :type-prefix
+              :type-start name-start
+              :at-pos at-pos))
+       ;; Case 3: no @ trigger
+       (t nil)))))
+
+;;;; Boundary Validation
+
+(defun duckdb-query-complete--in-sql-string-p (parse-result at-pos)
+  "Return non-nil if AT-POS is within the main SQL string.
+
+PARSE-RESULT is a `duckdb-query-parse-result' struct.
+AT-POS is the buffer position of the @ character.
+
+Returns non-nil when AT-POS falls between the opening and closing
+quotes of the main SQL string argument.
+
+Does not validate positions inside parameter value strings.
+Phase 1 restricts completion to the main SQL string only.
+
+Called by `duckdb-query-complete-at-point'."
+  (let ((sql-beg (duckdb-query-parse-result-sql-beg parse-result))
+        (sql-end (duckdb-query-parse-result-sql-end parse-result)))
+    (and sql-beg sql-end
+         (> at-pos sql-beg)
+         (< at-pos sql-end))))
+
+;;;; Candidate Generation
+
+(defun duckdb-query-complete--binding-candidates (parse-result type-str)
+  "Return binding name strings for TYPE-STR from PARSE-RESULT.
+
+PARSE-RESULT is a `duckdb-query-parse-result' struct.
+TYPE-STR is one of \"sql\", \"data\", \"val\", \"org\".
+
+Return list of name strings from the corresponding binding keyword,
+or nil if no bindings exist for that type.
+
+For \"org\" type, always returns nil (org references are resolved
+from external buffers, not from parsed bindings).
+
+Called by `duckdb-query-complete-at-point'.
+Uses `duckdb-query-parse-result-bindings' for data access."
+  (let ((keyword (intern (format ":%s" type-str))))
+    (mapcar #'symbol-name
+            (cdr (assq keyword
+                       (duckdb-query-parse-result-bindings parse-result))))))
+
+;;;; Annotation Functions
+
+(defun duckdb-query-complete--name-annotation (type-str)
+  "Return annotation function for binding name candidates.
+
+TYPE-STR is the reference type string (\"sql\", \"data\", \"val\").
+
+Return function suitable for :annotation-function property.
+
+Called by `duckdb-query-complete-at-point'."
+  (let ((suffix (format " @%s" type-str)))
+    (lambda (_candidate) suffix)))
+
+(defun duckdb-query-complete--type-annotation (candidate)
+  "Return annotation for type CANDIDATE.
+
+CANDIDATE is a string like \"sql:\", \"data:\", etc.
+
+Return description string from `duckdb-query-complete--type-annotations'.
+
+Used as :annotation-function for type prefix completion.
+Called by `duckdb-query-complete-at-point'."
+  (or (cdr (assoc candidate duckdb-query-complete--type-annotations))
+      ""))
+
+;;;; Main capf Entry Point
+
+(defun duckdb-query-complete-at-point ()
+  "Completion-at-point function for `duckdb-query' SQL strings.
+
+Return nil when point is not in a completable context.
+Return (START END COLLECTION . PROPS) for active completion.
+
+Completion contexts:
+
+  @type:partial-name  Complete binding names for that type.
+  @partial-type       Complete reference type prefixes.
+
+Fast rejection path:
+1. Not inside a string -- return nil immediately.
+2. Not inside a `duckdb-query' family form -- return nil.
+3. Not at an @ reference trigger -- return nil.
+
+Coexists with `elisp-completion-at-point' via :exclusive property
+set to \\='no, allowing fallback to other capf functions when this
+function has no applicable candidates.
+
+Install via `duckdb-query-complete-mode' or manually:
+
+  (add-hook \\='completion-at-point-functions
+            #\\='duckdb-query-complete-at-point -90 t)
+
+Uses `duckdb-query-complete--ref-context-at-point' for trigger detection.
+Uses `duckdb-query--parse-at-point' for structural analysis.
+Uses `duckdb-query-complete--binding-candidates' for candidate extraction."
+  ;; Fast rejection: must be inside a string
+  (when (nth 3 (syntax-ppss))
+    ;; Must be inside a duckdb-query family form
+    (when-let* ((parse-result (duckdb-query--parse-at-point))
+                (ref-ctx (duckdb-query-complete--ref-context-at-point)))
+      (let ((context (plist-get ref-ctx :context)))
+        (pcase context
+          ;; Context 1: @type:name -- complete binding names
+          (:type-name
+           (let ((type-str (plist-get ref-ctx :type))
+                 (name-start (plist-get ref-ctx :name-start))
+                 (at-pos (plist-get ref-ctx :at-pos)))
+             (when (duckdb-query-complete--in-sql-string-p
+                    parse-result at-pos)
+               (let ((candidates (duckdb-query-complete--binding-candidates
+                                  parse-result type-str)))
+                 (when candidates
+                   (list name-start (point) candidates
+                         :exclusive 'no
+                         :annotation-function
+                         (duckdb-query-complete--name-annotation
+                          type-str)))))))
+          ;; Context 2: @type-prefix -- complete type names
+          (:type-prefix
+           (let ((type-start (plist-get ref-ctx :type-start))
+                 (at-pos (plist-get ref-ctx :at-pos)))
+             (when (duckdb-query-complete--in-sql-string-p
+                    parse-result at-pos)
+               (list type-start (point)
+                     duckdb-query-complete--type-candidates
+                     :exclusive 'no
+                     :annotation-function
+                     #'duckdb-query-complete--type-annotation)))))))))
+
+;;;; Minor Mode
+
+;;;###autoload
+(define-minor-mode duckdb-query-complete-mode
+  "Completion for @type:name references in `duckdb-query' forms.
+
+When enabled, `completion-at-point' offers binding names as
+candidates when typing @type:name references inside SQL string
+arguments to `duckdb-query' and related functions.
+
+Works with corfu, company-mode, and default completion UI.
+
+Installed at depth -90 in `completion-at-point-functions' to run
+before `elisp-completion-at-point', which rejects string contexts.
+
+To enable globally:
+
+    (add-hook \\='emacs-lisp-mode-hook #\\='duckdb-query-complete-mode)
+
+Also see `duckdb-query-font-lock-mode' for reference highlighting.
+Also see `duckdb-query-complete-at-point' for the capf function."
+  :lighter nil
+  :group 'duckdb-query-complete
+  (if duckdb-query-complete-mode
+      (add-hook 'completion-at-point-functions
+                #'duckdb-query-complete-at-point -90 t)
+    (remove-hook 'completion-at-point-functions
+                 #'duckdb-query-complete-at-point t)))
+
+(provide 'duckdb-query-complete)
+
+;;; duckdb-query-complete.el ends here

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -561,7 +561,7 @@ Return alist of (NAME-STRING . DEFINITION-STRING) pairs.
 Return nil if the region does not contain a valid binding list.
 
 Handles quoted and backquoted forms.  Skips unquote markers
-(comma and comma-at).  Recognizes cons pairs by the dot separator
+\(comma and comma-at).  Recognizes cons pairs by the dot separator
 after the car symbol.
 
 Example for :val \\='((min_price . 25) (avg_revenue . (sql \"...\"))):

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -74,9 +74,83 @@ Also see `duckdb-query-complete-at-point'."
   :group 'duckdb-query-complete
   :package-version '(duckdb-query . "0.8.0"))
 
+(defcustom duckdb-query-complete-sql-source :cache
+  "Source for SQL autocompletion candidates.
+
+Controls how SQL keyword, function, and type candidates are
+obtained for completion at non-reference positions in SQL strings.
+
+  :cache - Query DuckDB metadata once at mode enable, serve from
+           buffer-local cache.  Zero latency per keystroke.
+           Refresh with `duckdb-query-complete-refresh-cache'.
+
+  :live  - Query DuckDB `sql_auto_complete' on each completion
+           request.  Context-aware but ~35ms latency per keystroke.
+           Best with session executor for ~2ms latency.
+
+Only effective when `duckdb-query-complete-sql-p' is non-nil.
+
+Also see `duckdb-query-complete-refresh-cache'.
+Also see `duckdb-query-complete-sql-p'."
+  :type '(choice (const :tag "Cached metadata (fast)" :cache)
+                 (const :tag "Live sql_auto_complete (context-aware)" :live))
+  :group 'duckdb-query-complete
+  :package-version '(duckdb-query . "0.8.0"))
+
 ;;;; Internal Variables
 (defconst duckdb-query-complete--sql-annotation " 🦆"
   "Annotation suffix for SQL autocompletion candidates.")
+
+(defconst duckdb-query-complete--cache-query
+  "SELECT label, type_label, priority FROM (
+  SELECT DISTINCT keyword_name AS label,
+    CASE WHEN keyword_category = 'reserved' THEN 'kw*' ELSE 'kw' END AS type_label,
+    CASE WHEN keyword_category = 'reserved' THEN 100 ELSE 1000 END AS priority
+  FROM duckdb_keywords()
+  UNION ALL
+  SELECT DISTINCT function_name AS label,
+    CASE WHEN function_type = 'aggregate' THEN 'agg'
+         WHEN function_type = 'macro' THEN 'macro'
+         WHEN function_type = 'table' THEN 'fn->T'
+         ELSE 'fn' END AS type_label,
+    1000 AS priority
+  FROM duckdb_functions()
+  WHERE function_name NOT IN (SELECT keyword_name FROM duckdb_keywords())
+  UNION ALL
+  SELECT DISTINCT type_name AS label, 'type' AS type_label, 1000 AS priority
+  FROM duckdb_types()
+  WHERE database_name = 'system'
+) ORDER BY priority, label"
+  "SQL query to populate the completion cache.
+
+Returns three columns: label, type_label, priority.
+Combines keywords, functions, and types from DuckDB metadata.
+Excludes function names that duplicate keyword names.
+Sorts by priority (reserved keywords first) then alphabetically.
+
+Called by `duckdb-query-complete--populate-cache'.")
+
+(defvar-local duckdb-query-complete--sql-cache nil
+  "Cached SQL completion candidates for current buffer.
+
+List of plists, each with :label, :type-label, and :priority keys.
+Populated by `duckdb-query-complete--populate-cache'.
+Invalidated by `duckdb-query-complete-refresh-cache'.
+
+When nil, the cache has not been populated.  When the symbol `empty',
+population was attempted but DuckDB was unavailable.
+
+Also see `duckdb-query-complete-sql-source'.")
+
+(defvar-local duckdb-query-complete--sql-candidates nil
+  "Flat list of candidate strings derived from `duckdb-query-complete--sql-cache'.
+
+Each string carries text properties:
+  `duckdb-query--type-label' - category string (\"kw*\", \"fn\", \"agg\", etc.)
+  `duckdb-query--priority'   - integer sort key (lower is higher priority)
+
+Rebuilt by `duckdb-query-complete--populate-cache'.
+Used by `duckdb-query-complete-at-point' for zero-latency filtering.")
 
 ;;;; Debugging Utilities
 (defvar duckdb-query-complete--debug t
@@ -245,6 +319,66 @@ Called by `duckdb-query-complete-at-point'."
               (and (> at-pos val-beg)
                    (< at-pos val-end))))))
       (duckdb-query-parse-result-params parse-result)))))
+
+;;;; SQL Completion Cache
+
+(defun duckdb-query-complete--populate-cache ()
+  "Populate SQL completion cache from DuckDB metadata.
+
+Query `duckdb_keywords', `duckdb_functions', and `duckdb_types'
+in a single statement.  Store raw results in
+`duckdb-query-complete--sql-cache' and build propertized string
+list in `duckdb-query-complete--sql-candidates'.
+
+Uses `duckdb-query-default-database' and session context if
+available.  Falls back to in-memory DuckDB when no database is
+configured.
+
+On error (DuckDB unavailable, network failure), set cache to
+symbol `empty' and log to debug buffer.  Does not signal errors.
+
+Called by `duckdb-query-complete-mode' on enable and by
+`duckdb-query-complete-refresh-cache' interactively."
+  (duckdb-query-complete--debug-log "populating SQL cache...")
+  (condition-case err
+      (let* ((rows (duckdb-query duckdb-query-complete--cache-query
+                                 :format :alist))
+             (candidates nil))
+        (dolist (row rows)
+          (let* ((label (cdr (assq 'label row)))
+                 (type-label (cdr (assq 'type_label row)))
+                 (priority (cdr (assq 'priority row)))
+                 (candidate (copy-sequence label)))
+            (put-text-property 0 (length candidate)
+                               'duckdb-query--type-label type-label
+                               candidate)
+            (put-text-property 0 (length candidate)
+                               'duckdb-query--priority priority
+                               candidate)
+            (push candidate candidates)))
+        (setq duckdb-query-complete--sql-cache rows)
+        (setq duckdb-query-complete--sql-candidates (nreverse candidates))
+        (duckdb-query-complete--debug-log
+         "SQL cache populated: %d candidates" (length candidates)))
+    (error
+     (duckdb-query-complete--debug-log "SQL cache population failed: %S" err)
+     (setq duckdb-query-complete--sql-cache 'empty)
+     (setq duckdb-query-complete--sql-candidates nil))))
+
+(defun duckdb-query-complete-refresh-cache ()
+  "Refresh the SQL completion cache from DuckDB metadata.
+
+Re-query `duckdb_keywords', `duckdb_functions', and `duckdb_types'
+and rebuild the candidate list.  Use after loading extensions or
+attaching databases that add new functions or types.
+
+Also see `duckdb-query-complete--populate-cache'."
+  (interactive)
+  (duckdb-query-complete--populate-cache)
+  (if (eq duckdb-query-complete--sql-cache 'empty)
+      (message "DuckDB SQL cache: population failed (see debug buffer)")
+    (message "DuckDB SQL cache: %d candidates"
+             (length duckdb-query-complete--sql-candidates))))
 
 ;;;; SQL Autocompletion
 
@@ -673,6 +807,11 @@ When enabled, `completion-at-point' offers binding names as
 candidates when typing @type:name references inside SQL string
 arguments to `duckdb-query' and related functions.
 
+When `duckdb-query-complete-sql-source' is `:cache' (the default),
+populate the SQL completion cache from DuckDB metadata on enable.
+Use `duckdb-query-complete-refresh-cache' to update after loading
+extensions or attaching databases.
+
 Works with corfu, company-mode, and default completion UI.
 
 Installed at depth -90 in `completion-at-point-functions' to run
@@ -687,8 +826,13 @@ Also see `duckdb-query-complete-at-point' for the capf function."
   :lighter nil
   :group 'duckdb-query-complete
   (if duckdb-query-complete-mode
-      (add-hook 'completion-at-point-functions
-                #'duckdb-query-complete-at-point -90 t)
+      (progn
+        (add-hook 'completion-at-point-functions
+                  #'duckdb-query-complete-at-point -90 t)
+        (when (and duckdb-query-complete-sql-p
+                   (eq duckdb-query-complete-sql-source :cache)
+                   (null duckdb-query-complete--sql-cache))
+          (duckdb-query-complete--populate-cache)))
     (remove-hook 'completion-at-point-functions
                  #'duckdb-query-complete-at-point t)))
 

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -401,6 +401,7 @@ Also see `duckdb-query-complete--populate-cache'."
     (message "DuckDB SQL cache: %d candidates"
              (length duckdb-query-complete--sql-candidates))))
 
+
 ;;;; SQL Autocompletion
 (defun duckdb-query-complete--sql-annotation (candidate)
   "Return annotation for SQL CANDIDATE from cached metadata.
@@ -548,6 +549,109 @@ Also see `duckdb-query-complete-toggle-debug' for logging."
      (duckdb-query-complete--debug-log "sql-candidates ERROR: %S" err)
      nil)))
 
+
+;;;; SQL Autocompcompletion - Static Analysis
+
+(defun duckdb-query-complete--extract-cte-names (parse-result)
+  "Extract CTE names from the SQL string in PARSE-RESULT.
+
+Scan the main SQL string for WITH ... AS patterns and collect
+the CTE names as completion candidates.
+
+Return list of propertized candidate strings with type-label \"cte\".
+
+Called by `duckdb-query-complete-at-point' for static enrichment."
+  (let ((sql-beg (duckdb-query-parse-result-sql-beg parse-result))
+        (sql-end (duckdb-query-parse-result-sql-end parse-result))
+        (names nil))
+    (when (and sql-beg sql-end)
+      (save-excursion
+        (goto-char sql-beg)
+        ;; Match: WITH name AS or , name AS
+        (while (re-search-forward
+                "\\(?:\\bWITH\\b\\|,\\)\\s-+\\([a-zA-Z_][a-zA-Z0-9_]*\\)\\s-+\\bAS\\b"
+                sql-end t)
+          (let* ((name (match-string-no-properties 1))
+                 (candidate (copy-sequence name)))
+            (put-text-property 0 (length candidate)
+                               'duckdb-query--type-label "cte"
+                               candidate)
+            (put-text-property 0 (length candidate)
+                               'duckdb-query--priority 50
+                               candidate)
+            (push candidate names)))))
+    (nreverse names)))
+
+(defun duckdb-query-complete--extract-alias-names (parse-result)
+  "Extract table aliases from the SQL string in PARSE-RESULT.
+
+Scan for FROM/JOIN ... alias patterns where alias is not a keyword.
+Return list of propertized candidate strings with type-label \"alias\".
+
+Called by `duckdb-query-complete-at-point' for static enrichment."
+  (let ((sql-beg (duckdb-query-parse-result-sql-beg parse-result))
+        (sql-end (duckdb-query-parse-result-sql-end parse-result))
+        (names nil)
+        ;; Common keywords that appear after table refs but are not aliases
+        (keywords '("WHERE" "ON" "JOIN" "LEFT" "RIGHT" "INNER" "OUTER"
+                    "CROSS" "FULL" "GROUP" "ORDER" "HAVING" "LIMIT"
+                    "UNION" "INTERSECT" "EXCEPT" "SET" "VALUES"
+                    "QUALIFY" "WINDOW" "USING" "AS" "SELECT")))
+    (when (and sql-beg sql-end)
+      (save-excursion
+        (goto-char sql-beg)
+        ;; Match: FROM/JOIN <source> <alias>
+        ;; where <source> can be identifier, @ref, or (...) subquery
+        (while (re-search-forward
+                "\\b\\(?:FROM\\|JOIN\\)\\s-+\\S-+\\s-+\\([a-zA-Z_][a-zA-Z0-9_]*\\)\\b"
+                sql-end t)
+          (let ((name (match-string-no-properties 1)))
+            (unless (member (upcase name) keywords)
+              (let ((candidate (copy-sequence name)))
+                (put-text-property 0 (length candidate)
+                                   'duckdb-query--type-label "alias"
+                                   candidate)
+                (put-text-property 0 (length candidate)
+                                   'duckdb-query--priority 50
+                                   candidate)
+                (push candidate names)))))))
+    (nreverse names)))
+
+(defun duckdb-query-complete--extract-data-table-names (parse-result)
+  "Extract @data: binding names as table-like candidates.
+
+PARSE-RESULT is a `duckdb-query-parse-result' struct.
+
+Return list of propertized candidate strings with type-label \"data\".
+These are the names that appear after FROM/JOIN as @data:name or @name.
+
+Called by `duckdb-query-complete-at-point' for static enrichment."
+  (let ((bindings (cdr (assq :data
+                              (duckdb-query-parse-result-bindings
+                               parse-result))))
+        (names nil))
+    (dolist (sym bindings)
+      (let* ((name (symbol-name sym))
+             (candidate (copy-sequence name)))
+        (put-text-property 0 (length candidate)
+                           'duckdb-query--type-label "data"
+                           candidate)
+        (put-text-property 0 (length candidate)
+                           'duckdb-query--priority 50
+                           candidate)
+        (push candidate names)))
+    (nreverse names)))
+
+(defun duckdb-query-complete--static-candidates (parse-result)
+  "Collect all static analysis candidates from PARSE-RESULT.
+
+Merge CTE names, table aliases, and @data: binding names into
+a single list of propertized candidates.
+
+Called by `duckdb-query-complete-at-point' in the SQL branch."
+  (append (duckdb-query-complete--extract-cte-names parse-result)
+          (duckdb-query-complete--extract-alias-names parse-result)
+          (duckdb-query-complete--extract-data-table-names parse-result)))
 
 ;;;; Candidate Generation
 
@@ -836,15 +940,22 @@ Also see `duckdb-query-complete-toggle-debug' for debug logging."
                 (pcase duckdb-query-complete-sql-source
                   ;; Cached mode: serve from buffer-local list
                   (:cache
-                   (let ((candidates (duckdb-query-complete--cached-sql-candidates)))
+                   (let* ((cached (duckdb-query-complete--cached-sql-candidates))
+                          (static (duckdb-query-complete--static-candidates
+                                   parse-result))
+                          (candidates (if static
+                                          (append static cached)
+                                        cached)))
                      (when candidates
                        (let ((word-start
                               (save-excursion
                                 (skip-chars-backward "a-zA-Z0-9_.")
                                 (point))))
                          (duckdb-query-complete--debug-log
-                          "SQL cache: %d candidates, start=%d end=%d"
-                          (length candidates) word-start (point))
+                          "SQL cache: %d cached + %d static, start=%d end=%d"
+                          (length (or cached '()))
+                          (length (or static '()))
+                          word-start (point))
                          (list word-start (point) candidates
                                :exclusive 'no
                                :company-prefix-length t

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -61,39 +61,18 @@
   "Whether to offer SQL autocompletion via DuckDB.
 
 When non-nil, `duckdb-query-complete-at-point' queries DuckDB's
-`sql_auto_complete' function for SQL keyword, table, column, and
-function suggestions at non-reference positions in SQL strings.
+metadata functions once at mode enable and serves SQL keyword,
+function, and type candidates from a buffer-local cache.
 
 When nil, only @type:name reference completion is offered.
 
-Requires DuckDB CLI or active session.  Falls back gracefully
-on error, returning nil to allow other capf functions to run.
+Requires DuckDB CLI or active session for initial cache population.
+Falls back gracefully on error, returning nil to allow other capf
+functions to run.
 
-Also see `duckdb-query-complete-at-point'."
+Also see `duckdb-query-complete-at-point'.
+Also see `duckdb-query-complete-refresh-cache'."
   :type 'boolean
-  :group 'duckdb-query-complete
-  :package-version '(duckdb-query . "0.8.0"))
-
-(defcustom duckdb-query-complete-sql-source :cache
-  "Source for SQL autocompletion candidates.
-
-Controls how SQL keyword, function, and type candidates are
-obtained for completion at non-reference positions in SQL strings.
-
-  :cache - Query DuckDB metadata once at mode enable, serve from
-           buffer-local cache.  Zero latency per keystroke.
-           Refresh with `duckdb-query-complete-refresh-cache'.
-
-  :live  - Query DuckDB `sql_auto_complete' on each completion
-           request.  Context-aware but ~35ms latency per keystroke.
-           Best with session executor for ~2ms latency.
-
-Only effective when `duckdb-query-complete-sql-p' is non-nil.
-
-Also see `duckdb-query-complete-refresh-cache'.
-Also see `duckdb-query-complete-sql-p'."
-  :type '(choice (const :tag "Cached metadata (fast)" :cache)
-                 (const :tag "Live sql_auto_complete (context-aware)" :live))
   :group 'duckdb-query-complete
   :package-version '(duckdb-query . "0.8.0"))
 
@@ -465,104 +444,6 @@ Called by `duckdb-query-complete-at-point' in :cache mode."
   (unless (eq duckdb-query-complete--sql-cache 'empty)
     duckdb-query-complete--sql-candidates))
 
-(defun duckdb-query-complete--sanitize-for-autocomplete (sql parse-result)
-  "Replace @type:name references in SQL with parseable substitutions.
-
-SQL is a partial query string extracted from a buffer.
-PARSE-RESULT is a `duckdb-query-parse-result' struct, used to
-read actual @sql: fragment definitions from the buffer.
-
-Return modified SQL string suitable for `sql_auto_complete'.
-
-For @sql: references, inline the actual SQL fragment text from
-the corresponding :sql parameter binding.  This gives
-`sql_auto_complete' the full query structure for context-aware
-suggestions.
-
-For other reference types, use syntactic placeholders:
-  @val:name   becomes  getvariable(\\='name\\=')
-  @data:name  becomes  __data_name
-  @org:name   becomes  __org_name
-  @name       becomes  __data_name  (shorthand form)
-
-Called by `duckdb-query-complete-at-point'.
-Uses `duckdb-query-complete--binding-definitions' for @sql: values."
-  (let ((result sql)
-        (sql-defs (when parse-result
-                    (duckdb-query-complete--binding-definitions
-                     parse-result "sql"))))
-    ;; Inline @sql: fragments with actual definitions
-    (when sql-defs
-      (dolist (def sql-defs)
-        (let* ((name (car def))
-               (value (cdr def))
-               ;; Strip surrounding quotes from the definition text
-               (clean-value (if (and (> (length value) 1)
-                                     (eq (aref value 0) ?\")
-                                     (eq (aref value (1- (length value))) ?\"))
-                                (substring value 1 -1)
-                              value))
-               (pattern (format "@sql:%s\\b" (regexp-quote name))))
-          (setq result (replace-regexp-in-string
-                        pattern clean-value result t t)))))
-    ;; Other reference types
-    (setq result (replace-regexp-in-string
-                  "@val:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
-                  "getvariable('\\1')"
-                  result t))
-    (setq result (replace-regexp-in-string
-                  "@data:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
-                  "__data_\\1"
-                  result t))
-    (setq result (replace-regexp-in-string
-                  "@org:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
-                  "__org_\\1"
-                  result t))
-    ;; Shorthand @name form last
-    (setq result (replace-regexp-in-string
-                  "@\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
-                  "__data_\\1"
-                  result t))
-    result))
-
-(defun duckdb-query-complete--sql-candidates (sanitized-sql)
-  "Fetch SQL autocompletion candidates from DuckDB.
-
-SANITIZED-SQL is a query string with references already replaced
-by `duckdb-query-complete--sanitize-for-autocomplete'.
-
-Return list of alists with `suggestion' and `suggestion_start'
-keys, or nil on error.
-
-Uses `duckdb-query' with the current session executor if inside
-`duckdb-query-with-session', otherwise uses :cli executor with
-`duckdb-query-default-database' if set.
-
-Errors from DuckDB (malformed SQL, unavailable CLI) are caught,
-logged to the debug buffer, and return nil silently.
-
-Called by `duckdb-query-complete-at-point'.
-Also see `duckdb-query-complete-toggle-debug' for logging."
-  (duckdb-query-complete--debug-log "sql-candidates query:\n  %s"
-                                    sanitized-sql)
-  (condition-case err
-      (let ((results
-             (duckdb-query
-              "SELECT suggestion, suggestion_start FROM sql_auto_complete(@val:q)"
-              :val `((q . ,sanitized-sql))
-              :format :alist)))
-        (duckdb-query-complete--debug-log "sql-candidates results: %d rows"
-                                          (length results))
-        (duckdb-query-complete--debug-log "  candidates: %S"
-                                          (mapcar (lambda (r)
-                                                    (cdr (assq 'suggestion r)))
-                                                  results))
-        results)
-    (error
-     (duckdb-query-complete--debug-log "sql-candidates ERROR: %S" err)
-     nil)))
-
-
 ;;;; SQL Autocompcompletion - Static Analysis
 
 (defun duckdb-query-complete--extract-cte-names (parse-result)
@@ -833,7 +714,7 @@ Completion contexts, checked in order:
 
   @type:partial-name  Complete binding names for that type.
   @partial-type       Complete reference type prefixes.
-  plain SQL text      Complete via `sql_auto_complete' (when enabled).
+  plain SQL text      Complete SQL keywords, functions, types from cache.
 
 Completable string positions:
 - Main SQL string argument to `duckdb-query' family functions
@@ -848,17 +729,16 @@ For reference contexts:
 4. @ position not in a completable string -- return nil.
 
 For SQL completion (when `duckdb-query-complete-sql-p' is non-nil):
-5. Extract partial SQL from string start to point.
-6. Sanitize references using parse result for @sql: inlining.
-7. Query DuckDB `sql_auto_complete' for suggestions.
-8. Map `suggestion_start' offset to buffer positions for START.
+5. Serve cached candidates from `duckdb-query-complete--sql-candidates'.
+6. Merge with static analysis candidates (CTEs, aliases, data bindings).
+7. Use backward word scan from point for START position.
 
 Reference completion uses :exclusive t to prevent other capf
 functions (notably `cape-dabbrev') from providing conflicting
 candidates when inside a recognized @type:name context.
 
-SQL completion uses :exclusive no to allow fallback when DuckDB
-returns no suggestions.
+SQL completion uses :exclusive no to allow fallback when cache
+is empty or DuckDB was unavailable at mode enable.
 
 Both branches use :company-prefix-length t to force corfu
 auto-completion regardless of `corfu-auto-prefix' threshold.
@@ -867,15 +747,13 @@ Name candidates display binding definitions via
 :affixation-function.  Each candidate shows the value expression
 from the corresponding parameter binding.
 
-SQL candidates are annotated with a duck emoji to distinguish
-them from reference candidates and dabbrev suggestions.
-
-@sql: references are inlined with their actual fragment text
-before sending to `sql_auto_complete', giving DuckDB the full
-query structure for context-aware suggestions.
+SQL candidates are annotated with category labels (kw*, fn, fn/a,
+fn->T, type, etc.) from cached DuckDB metadata.  Static analysis
+candidates (CTEs, aliases, data bindings) sort before DuckDB
+metadata via priority 50 < 100.
 
 When `duckdb-query-complete--debug' is non-nil, all capf calls,
-SQL queries, errors, and candidate lists are logged to the
+candidate counts, and errors are logged to the
 *duckdb-complete-debug* buffer.
 
 When this function returns nil (not in a completable context),
@@ -891,8 +769,8 @@ Uses `duckdb-query--parse-at-point' for structural analysis.
 Uses `duckdb-query-complete--in-completable-string-p' for boundary check.
 Uses `duckdb-query-complete--binding-candidates' for candidate extraction.
 Uses `duckdb-query-complete--binding-definitions' for value display.
-Uses `duckdb-query-complete--sanitize-for-autocomplete' for SQL cleanup.
-Uses `duckdb-query-complete--sql-candidates' for SQL autocompletion.
+Uses `duckdb-query-complete--cached-sql-candidates' for SQL candidates.
+Uses `duckdb-query-complete--static-candidates' for parser-derived candidates.
 Also see `duckdb-query-complete-toggle-debug' for debug logging."
   (duckdb-query-complete--debug-log "capf called at point=%d" (point))
   ;; Fast rejection: must be inside a string
@@ -950,62 +828,29 @@ Also see `duckdb-query-complete-toggle-debug' for debug logging."
               (when (and sql-beg sql-end
                          (> (point) sql-beg)
                          (< (point) sql-end))
-                (pcase duckdb-query-complete-sql-source
-                  ;; Cached mode: serve from buffer-local list
-                  (:cache
-                   (let* ((cached (duckdb-query-complete--cached-sql-candidates))
-                          (static (duckdb-query-complete--static-candidates
-                                   parse-result))
-                          (candidates (if static
-                                          (append static cached)
-                                        cached)))
-                     (when candidates
-                       (let ((word-start
-                              (save-excursion
-                                (skip-chars-backward "a-zA-Z0-9_.")
-                                (point))))
-                         (duckdb-query-complete--debug-log
-                          "SQL cache: %d cached + %d static, start=%d end=%d"
-                          (length (or cached '()))
-                          (length (or static '()))
-                          word-start (point))
-                         (list word-start (point) candidates
-                               :exclusive 'no
-                               :company-prefix-length t
-                               :annotation-function
-                               #'duckdb-query-complete--sql-annotation
-                               :display-sort-function
-                               #'duckdb-query-complete--sql-sort)))))
-                  ;; Live mode: query sql_auto_complete per request
-                  (:live
-                   (let* ((str-start (nth 8 (syntax-ppss)))
-                          (content-start (1+ str-start))
-                          (partial-sql
-                           (buffer-substring-no-properties
-                            content-start (point)))
-                          (sanitized-sql
-                           (duckdb-query-complete--sanitize-for-autocomplete
-                            partial-sql parse-result))
-                          (raw-results
-                           (duckdb-query-complete--sql-candidates
-                            sanitized-sql)))
-                     (when raw-results
-                       (let* ((word-start
-                               (save-excursion
-                                 (skip-chars-backward "a-zA-Z0-9_.")
-                                 (point)))
-                              (candidates
-                               (mapcar (lambda (row)
-                                         (cdr (assq 'suggestion row)))
-                                       raw-results)))
-                         (duckdb-query-complete--debug-log
-                          "SQL live: %d candidates, start=%d end=%d"
-                          (length candidates) word-start (point))
-                         (list word-start (point) candidates
-                               :exclusive 'no
-                               :company-prefix-length t
-                               :annotation-function
-                               (lambda (_) " ddb")))))))))))))))
+                (let* ((cached (duckdb-query-complete--cached-sql-candidates))
+                       (static (duckdb-query-complete--static-candidates
+                                parse-result))
+                       (candidates (if static
+                                       (append static cached)
+                                     cached)))
+                  (when candidates
+                    (let ((word-start
+                           (save-excursion
+                             (skip-chars-backward "a-zA-Z0-9_.")
+                             (point))))
+                      (duckdb-query-complete--debug-log
+                       "SQL cache: %d cached + %d static, start=%d end=%d"
+                       (length (or cached '()))
+                       (length (or static '()))
+                       word-start (point))
+                      (list word-start (point) candidates
+                            :exclusive 'no
+                            :company-prefix-length t
+                            :annotation-function
+                            #'duckdb-query-complete--sql-annotation
+                            :display-sort-function
+                            #'duckdb-query-complete--sql-sort))))))))))))
 
 ;;;; Minor Mode
 
@@ -1017,9 +862,9 @@ When enabled, `completion-at-point' offers binding names as
 candidates when typing @type:name references inside SQL string
 arguments to `duckdb-query' and related functions.
 
-When `duckdb-query-complete-sql-source' is `:cache' (the default),
-populate the SQL completion cache from DuckDB metadata on enable.
-Use `duckdb-query-complete-refresh-cache' to update after loading
+When `duckdb-query-complete-sql-p' is non-nil, populate the SQL
+completion cache from DuckDB metadata on enable.  Use
+`duckdb-query-complete-refresh-cache' to update after loading
 extensions or attaching databases.
 
 Works with corfu, company-mode, and default completion UI.
@@ -1040,7 +885,6 @@ Also see `duckdb-query-complete-at-point' for the capf function."
         (add-hook 'completion-at-point-functions
                   #'duckdb-query-complete-at-point -90 t)
         (when (and duckdb-query-complete-sql-p
-                   (eq duckdb-query-complete-sql-source :cache)
                    (null duckdb-query-complete--sql-cache))
           (duckdb-query-complete--populate-cache)))
     (remove-hook 'completion-at-point-functions

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -327,6 +327,11 @@ in a single statement.  Store raw results in
 `duckdb-query-complete--sql-cache' and build propertized string
 list in `duckdb-query-complete--sql-candidates'.
 
+For keywords (type-label starting with \"kw\"), generate both
+uppercase and lowercase candidates so completion works regardless
+of user's typing case.  Functions and types are stored as returned
+by DuckDB (typically lowercase for functions, uppercase for types).
+
 Uses `duckdb-query-default-database' and session context if
 available.  Falls back to in-memory DuckDB when no database is
 configured.
@@ -340,19 +345,38 @@ Called by `duckdb-query-complete-mode' on enable and by
   (condition-case err
       (let* ((rows (duckdb-query duckdb-query-complete--cache-query
                                  :format :alist))
-             (candidates nil))
+             (candidates nil)
+             (seen (make-hash-table :test 'equal)))
         (dolist (row rows)
           (let* ((label (cdr (assq 'label row)))
                  (type-label (cdr (assq 'type_label row)))
-                 (priority (cdr (assq 'priority row)))
-                 (candidate (copy-sequence label)))
-            (put-text-property 0 (length candidate)
-                               'duckdb-query--type-label type-label
-                               candidate)
-            (put-text-property 0 (length candidate)
-                               'duckdb-query--priority priority
-                               candidate)
-            (push candidate candidates)))
+                 (priority (cdr (assq 'priority row))))
+            ;; Add the original form
+            (unless (gethash label seen)
+              (puthash label t seen)
+              (let ((candidate (copy-sequence label)))
+                (put-text-property 0 (length candidate)
+                                   'duckdb-query--type-label type-label
+                                   candidate)
+                (put-text-property 0 (length candidate)
+                                   'duckdb-query--priority priority
+                                   candidate)
+                (push candidate candidates)))
+            ;; For keywords, also add the other case
+            (when (string-prefix-p "kw" type-label)
+              (let ((alt (if (equal label (upcase label))
+                             (downcase label)
+                           (upcase label))))
+                (unless (gethash alt seen)
+                  (puthash alt t seen)
+                  (let ((candidate (copy-sequence alt)))
+                    (put-text-property 0 (length candidate)
+                                       'duckdb-query--type-label type-label
+                                       candidate)
+                    (put-text-property 0 (length candidate)
+                                       'duckdb-query--priority priority
+                                       candidate)
+                    (push candidate candidates)))))))
         (setq duckdb-query-complete--sql-cache rows)
         (setq duckdb-query-complete--sql-candidates (nreverse candidates))
         (duckdb-query-complete--debug-log

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -106,9 +106,11 @@ Also see `duckdb-query-complete-sql-p'."
   FROM duckdb_keywords()
   UNION ALL
   SELECT DISTINCT function_name AS label,
-    CASE WHEN function_type = 'aggregate' THEN 'agg'
-         WHEN function_type = 'macro' THEN 'macro'
+    CASE WHEN function_type = 'pragma' THEN 'pragma'
+         WHEN function_type = 'aggregate' THEN 'fn/a'
+         WHEN function_type = 'macro' THEN 'fn/m'
          WHEN function_type = 'table' THEN 'fn->T'
+         WHEN function_type = 'table_macro' THEN 'fn/m->T'
          ELSE 'fn' END AS type_label,
     1000 AS priority
   FROM duckdb_functions()
@@ -124,6 +126,17 @@ Returns three columns: label, type_label, priority.
 Combines keywords, functions, and types from DuckDB metadata.
 Excludes function names that duplicate keyword names.
 Sorts by priority (reserved keywords first) then alphabetically.
+
+Type labels:
+  kw*    - reserved SQL keyword
+  kw     - unreserved SQL keyword
+  fn     - scalar function
+  fn/a   - aggregate function
+  fn/m   - SQL macro
+  fn->T  - table-producing function
+  fn/m->T - table-producing macro
+  pragma - pragma function
+  type   - data type
 
 Called by `duckdb-query-complete--populate-cache'.")
 

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -93,6 +93,32 @@ Also see `duckdb-query-complete-refresh-cache'."
   :group 'duckdb-query-complete
   :package-version '(duckdb-query . "0.8.0"))
 
+(defcustom duckdb-query-complete-trigger 'always
+  "When to offer `duckdb-query' completion candidates.
+
+Controls whether `duckdb-query-complete-at-point' returns candidates
+during automatic (idle) completion or only on explicit invocation.
+
+  `always'  - Return candidates on every capf call (default).
+              Works with corfu-auto, company-idle-delay, and
+              manual triggers.
+
+  `manual'  - Return candidates only when completion is explicitly
+              invoked via `completion-at-point', `corfu-complete',
+              or equivalent command.  Suppresses candidates during
+              idle/automatic completion triggered by typing.
+
+The `manual' setting is useful when automatic SQL completion
+interferes with normal typing flow.  Reference completion
+\(@type:name) always activates regardless of this setting, since
+it triggers only after the explicit @ character.
+
+Also see `duckdb-query-complete-at-point'."
+  :type '(choice (const :tag "Always (automatic and manual)" always)
+                 (const :tag "Manual invocation only" manual))
+  :group 'duckdb-query-complete
+  :package-version '(duckdb-query . "0.8.0"))
+
 ;;;; Internal Variables
 (defconst duckdb-query-complete--cache-query
   "SELECT label, type_label, priority FROM (
@@ -766,6 +792,24 @@ Returns capf result or nil."
                  parse-result ref-ctx)))))))))
 
 ;;;; Dispatch Logic
+(defun duckdb-query-complete--manual-trigger-p ()
+  "Return non-nil if completion was explicitly invoked by the user.
+
+Detect manual invocation by checking `this-command' against known
+completion commands.  Returns nil during idle/automatic completion
+where `this-command' is typically `self-insert-command'.
+
+Called by `duckdb-query-complete--dispatch' when
+`duckdb-query-complete-trigger' is `manual'."
+  (memq this-command
+        '(completion-at-point
+          corfu-complete
+          company-complete
+          company-manual-begin
+          cape-complete
+          hippie-expand
+          indent-for-tab-command)))
+
 (defun duckdb-query-complete--dispatch (parse-result ref-ctx)
   "Dispatch completion based on PARSE-RESULT and REF-CTX.
 
@@ -818,7 +862,9 @@ Called by `duckdb-query-complete-at-point' and
                      :annotation-function
                      #'duckdb-query-complete--type-annotation))))))
     ;; SQL completion branch
-    (when duckdb-query-complete-sql-p
+    (when (and duckdb-query-complete-sql-p
+               (or (eq duckdb-query-complete-trigger 'always)
+                   (duckdb-query-complete--manual-trigger-p)))
       (let* ((sql-beg (duckdb-query-parse-result-sql-beg
                        parse-result))
              (sql-end (duckdb-query-parse-result-sql-end

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -451,7 +451,7 @@ right-aligned category label.
 Return \" kw*\" for reserved keywords, \" fn\" for scalar
 functions, \" agg\" for aggregates, etc.
 
-Falls back to duck emoji when candidate has no type property
+Falls back to \"ddb\" when candidate has no type property
 \(live mode candidates).
 
 Called as :annotation-function in SQL completion branch."

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -142,7 +142,7 @@ Rebuilt by `duckdb-query-complete--populate-cache'.
 Used by `duckdb-query-complete-at-point' for zero-latency filtering.")
 
 ;;;; Debugging Utilities
-(defvar duckdb-query-complete--debug t
+(defvar duckdb-query-complete--debug nil
   "When non-nil, log completion events to *duckdb-complete-debug* buffer.")
 
 (defun duckdb-query-complete--debug-log (fmt &rest args)

--- a/duckdb-query-complete.el
+++ b/duckdb-query-complete.el
@@ -48,6 +48,7 @@
 
 (require 'cl-lib)
 (require 'duckdb-query-parse)
+(require 'duckdb-query)
 
 ;;;; Customization
 
@@ -55,6 +56,62 @@
   "Completion support for `duckdb-query' SQL strings."
   :group 'duckdb-query
   :prefix "duckdb-query-complete-")
+
+(defcustom duckdb-query-complete-sql-p t
+  "Whether to offer SQL autocompletion via DuckDB.
+
+When non-nil, `duckdb-query-complete-at-point' queries DuckDB's
+`sql_auto_complete' function for SQL keyword, table, column, and
+function suggestions at non-reference positions in SQL strings.
+
+When nil, only @type:name reference completion is offered.
+
+Requires DuckDB CLI or active session.  Falls back gracefully
+on error, returning nil to allow other capf functions to run.
+
+Also see `duckdb-query-complete-at-point'."
+  :type 'boolean
+  :group 'duckdb-query-complete
+  :package-version '(duckdb-query . "0.8.0"))
+
+;;;; Internal Variables
+(defconst duckdb-query-complete--sql-annotation " 🦆"
+  "Annotation suffix for SQL autocompletion candidates.")
+
+;;;; Debugging Utilities
+(defvar duckdb-query-complete--debug t
+  "When non-nil, log completion events to *duckdb-complete-debug* buffer.")
+
+(defun duckdb-query-complete--debug-log (fmt &rest args)
+  "Log formatted message to debug buffer when debugging is active.
+
+FMT is a format string.  ARGS are format arguments.
+
+Only logs when `duckdb-query-complete--debug' is non-nil.
+Creates *duckdb-complete-debug* buffer on first use.
+
+Called by `duckdb-query-complete-at-point' and
+`duckdb-query-complete--sql-candidates'."
+  (when duckdb-query-complete--debug
+    (let ((buf (get-buffer-create "*duckdb-complete-debug*")))
+      (with-current-buffer buf
+        (goto-char (point-max))
+        (insert (format-time-string "[%H:%M:%S] ")
+                (apply #'format fmt args)
+                "\n")))))
+
+(defun duckdb-query-complete-toggle-debug ()
+  "Toggle completion debug logging.
+
+When enabled, all capf calls, SQL queries, errors, and candidate
+lists are logged to the *duckdb-complete-debug* buffer."
+  (interactive)
+  (setq duckdb-query-complete--debug (not duckdb-query-complete--debug))
+  (if duckdb-query-complete--debug
+      (progn
+        (get-buffer-create "*duckdb-complete-debug*")
+        (message "duckdb-query completion debug ON"))
+    (message "duckdb-query completion debug OFF")))
 
 ;;;; Reference Type Constants
 
@@ -188,6 +245,106 @@ Called by `duckdb-query-complete-at-point'."
               (and (> at-pos val-beg)
                    (< at-pos val-end))))))
       (duckdb-query-parse-result-params parse-result)))))
+
+;;;; SQL Autocompletion
+
+(defun duckdb-query-complete--sanitize-for-autocomplete (sql parse-result)
+  "Replace @type:name references in SQL with parseable substitutions.
+
+SQL is a partial query string extracted from a buffer.
+PARSE-RESULT is a `duckdb-query-parse-result' struct, used to
+read actual @sql: fragment definitions from the buffer.
+
+Return modified SQL string suitable for `sql_auto_complete'.
+
+For @sql: references, inline the actual SQL fragment text from
+the corresponding :sql parameter binding.  This gives
+`sql_auto_complete' the full query structure for context-aware
+suggestions.
+
+For other reference types, use syntactic placeholders:
+  @val:name   becomes  getvariable(\\='name\\=')
+  @data:name  becomes  __data_name
+  @org:name   becomes  __org_name
+  @name       becomes  __data_name  (shorthand form)
+
+Called by `duckdb-query-complete-at-point'.
+Uses `duckdb-query-complete--binding-definitions' for @sql: values."
+  (let ((result sql)
+        (sql-defs (when parse-result
+                    (duckdb-query-complete--binding-definitions
+                     parse-result "sql"))))
+    ;; Inline @sql: fragments with actual definitions
+    (when sql-defs
+      (dolist (def sql-defs)
+        (let* ((name (car def))
+               (value (cdr def))
+               ;; Strip surrounding quotes from the definition text
+               (clean-value (if (and (> (length value) 1)
+                                     (eq (aref value 0) ?\")
+                                     (eq (aref value (1- (length value))) ?\"))
+                                (substring value 1 -1)
+                              value))
+               (pattern (format "@sql:%s\\b" (regexp-quote name))))
+          (setq result (replace-regexp-in-string
+                        pattern clean-value result t t)))))
+    ;; Other reference types
+    (setq result (replace-regexp-in-string
+                  "@val:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
+                  "getvariable('\\1')"
+                  result t))
+    (setq result (replace-regexp-in-string
+                  "@data:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
+                  "__data_\\1"
+                  result t))
+    (setq result (replace-regexp-in-string
+                  "@org:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
+                  "__org_\\1"
+                  result t))
+    ;; Shorthand @name form last
+    (setq result (replace-regexp-in-string
+                  "@\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
+                  "__data_\\1"
+                  result t))
+    result))
+
+(defun duckdb-query-complete--sql-candidates (sanitized-sql)
+  "Fetch SQL autocompletion candidates from DuckDB.
+
+SANITIZED-SQL is a query string with references already replaced
+by `duckdb-query-complete--sanitize-for-autocomplete'.
+
+Return list of alists with `suggestion' and `suggestion_start'
+keys, or nil on error.
+
+Uses `duckdb-query' with the current session executor if inside
+`duckdb-query-with-session', otherwise uses :cli executor with
+`duckdb-query-default-database' if set.
+
+Errors from DuckDB (malformed SQL, unavailable CLI) are caught,
+logged to the debug buffer, and return nil silently.
+
+Called by `duckdb-query-complete-at-point'.
+Also see `duckdb-query-complete-toggle-debug' for logging."
+  (duckdb-query-complete--debug-log "sql-candidates query:\n  %s"
+                                    sanitized-sql)
+  (condition-case err
+      (let ((results
+             (duckdb-query
+              "SELECT suggestion, suggestion_start FROM sql_auto_complete(@val:q)"
+              :val `((q . ,sanitized-sql))
+              :format :alist)))
+        (duckdb-query-complete--debug-log "sql-candidates results: %d rows"
+                                          (length results))
+        (duckdb-query-complete--debug-log "  candidates: %S"
+                                          (mapcar (lambda (r)
+                                                    (cdr (assq 'suggestion r)))
+                                                  results))
+        results)
+    (error
+     (duckdb-query-complete--debug-log "sql-candidates ERROR: %S" err)
+     nil)))
+
 
 ;;;; Candidate Generation
 
@@ -352,10 +509,11 @@ Called by `duckdb-query-complete-at-point'."
 Return nil when point is not in a completable context.
 Return (START END COLLECTION . PROPS) for active completion.
 
-Completion contexts:
+Completion contexts, checked in order:
 
   @type:partial-name  Complete binding names for that type.
   @partial-type       Complete reference type prefixes.
+  plain SQL text      Complete via `sql_auto_complete' (when enabled).
 
 Completable string positions:
 - Main SQL string argument to `duckdb-query' family functions
@@ -364,21 +522,41 @@ Completable string positions:
 Fast rejection path:
 1. Not inside a string -- return nil immediately.
 2. Not inside a `duckdb-query' family form -- return nil.
-3. Not at an @ reference trigger -- return nil.
+
+For reference contexts:
+3. At an @ reference trigger -- return binding candidates.
 4. @ position not in a completable string -- return nil.
+
+For SQL completion (when `duckdb-query-complete-sql-p' is non-nil):
+5. Extract partial SQL from string start to point.
+6. Sanitize references using parse result for @sql: inlining.
+7. Query DuckDB `sql_auto_complete' for suggestions.
+8. Map `suggestion_start' offset to buffer positions for START.
 
 Reference completion uses :exclusive t to prevent other capf
 functions (notably `cape-dabbrev') from providing conflicting
 candidates when inside a recognized @type:name context.
 
-Uses :company-prefix-length t to force corfu auto-completion
-regardless of `corfu-auto-prefix' threshold.  Without this,
-corfu ignores our candidates when the completion region (text
-after the colon) is shorter than `corfu-auto-prefix'.
+SQL completion uses :exclusive no to allow fallback when DuckDB
+returns no suggestions.
+
+Both branches use :company-prefix-length t to force corfu
+auto-completion regardless of `corfu-auto-prefix' threshold.
 
 Name candidates display binding definitions via
 :affixation-function.  Each candidate shows the value expression
 from the corresponding parameter binding.
+
+SQL candidates are annotated with a duck emoji to distinguish
+them from reference candidates and dabbrev suggestions.
+
+@sql: references are inlined with their actual fragment text
+before sending to `sql_auto_complete', giving DuckDB the full
+query structure for context-aware suggestions.
+
+When `duckdb-query-complete--debug' is non-nil, all capf calls,
+SQL queries, errors, and candidate lists are logged to the
+*duckdb-complete-debug* buffer.
 
 When this function returns nil (not in a completable context),
 other capf functions run normally.
@@ -392,45 +570,98 @@ Uses `duckdb-query-complete--ref-context-at-point' for trigger detection.
 Uses `duckdb-query--parse-at-point' for structural analysis.
 Uses `duckdb-query-complete--in-completable-string-p' for boundary check.
 Uses `duckdb-query-complete--binding-candidates' for candidate extraction.
-Uses `duckdb-query-complete--binding-definitions' for value display."
+Uses `duckdb-query-complete--binding-definitions' for value display.
+Uses `duckdb-query-complete--sanitize-for-autocomplete' for SQL cleanup.
+Uses `duckdb-query-complete--sql-candidates' for SQL autocompletion.
+Also see `duckdb-query-complete-toggle-debug' for debug logging."
+  (duckdb-query-complete--debug-log "capf called at point=%d" (point))
   ;; Fast rejection: must be inside a string
   (when (nth 3 (syntax-ppss))
     ;; Must be inside a duckdb-query family form
-    (when-let* ((parse-result (duckdb-query--parse-at-point))
-                (ref-ctx (duckdb-query-complete--ref-context-at-point)))
-      (let ((context (plist-get ref-ctx :context)))
-        (pcase context
-          ;; Context 1: @type:name -- complete binding names
-          (:type-name
-           (let ((type-str (plist-get ref-ctx :type))
-                 (name-start (plist-get ref-ctx :name-start))
-                 (at-pos (plist-get ref-ctx :at-pos)))
-             (when (duckdb-query-complete--in-completable-string-p
-                    parse-result at-pos)
-               (let ((candidates (duckdb-query-complete--binding-candidates
-                                  parse-result type-str)))
-                 (when candidates
-                   (let ((definitions
-                          (duckdb-query-complete--binding-definitions
-                           parse-result type-str)))
-                     (list name-start (point) candidates
+    (when-let* ((parse-result (duckdb-query--parse-at-point)))
+      (let ((ref-ctx (duckdb-query-complete--ref-context-at-point)))
+        (duckdb-query-complete--debug-log "ref-ctx=%S" ref-ctx)
+        (if ref-ctx
+            ;; Reference completion branch
+            (let ((context (plist-get ref-ctx :context)))
+              (pcase context
+                ;; Context 1: @type:name -- complete binding names
+                (:type-name
+                 (let ((type-str (plist-get ref-ctx :type))
+                       (name-start (plist-get ref-ctx :name-start))
+                       (at-pos (plist-get ref-ctx :at-pos)))
+                   (when (duckdb-query-complete--in-completable-string-p
+                          parse-result at-pos)
+                     (let ((candidates
+                            (duckdb-query-complete--binding-candidates
+                             parse-result type-str)))
+                       (duckdb-query-complete--debug-log
+                        "ref @%s: candidates=%S" type-str candidates)
+                       (when candidates
+                         (let ((definitions
+                                (duckdb-query-complete--binding-definitions
+                                 parse-result type-str)))
+                           (list name-start (point) candidates
+                                 :exclusive t
+                                 :company-prefix-length t
+                                 :affixation-function
+                                 (duckdb-query-complete--name-affixation
+                                  type-str definitions))))))))
+                ;; Context 2: @type-prefix -- complete type names
+                (:type-prefix
+                 (let ((type-start (plist-get ref-ctx :type-start))
+                       (at-pos (plist-get ref-ctx :at-pos)))
+                   (when (duckdb-query-complete--in-completable-string-p
+                          parse-result at-pos)
+                     (duckdb-query-complete--debug-log "type-prefix completion")
+                     (list type-start (point)
+                           duckdb-query-complete--type-candidates
                            :exclusive t
                            :company-prefix-length t
-                           :affixation-function
-                           (duckdb-query-complete--name-affixation
-                            type-str definitions))))))))
-          ;; Context 2: @type-prefix -- complete type names
-          (:type-prefix
-           (let ((type-start (plist-get ref-ctx :type-start))
-                 (at-pos (plist-get ref-ctx :at-pos)))
-             (when (duckdb-query-complete--in-completable-string-p
-                    parse-result at-pos)
-               (list type-start (point)
-                     duckdb-query-complete--type-candidates
-                     :exclusive t
-                     :company-prefix-length t
-                     :annotation-function
-                     #'duckdb-query-complete--type-annotation)))))))))
+                           :annotation-function
+                           #'duckdb-query-complete--type-annotation))))))
+          ;; SQL completion branch
+          (when duckdb-query-complete-sql-p
+            (let* ((str-start (nth 8 (syntax-ppss)))
+                   (content-start (1+ str-start))
+                   (sql-beg (duckdb-query-parse-result-sql-beg
+                             parse-result))
+                   (sql-end (duckdb-query-parse-result-sql-end
+                             parse-result)))
+              ;; Only complete in main SQL string
+              (when (and sql-beg sql-end
+                         (> (point) sql-beg)
+                         (< (point) sql-end))
+                (let* ((partial-sql
+                        (buffer-substring-no-properties
+                         content-start (point)))
+                       (sanitized-sql
+                        (duckdb-query-complete--sanitize-for-autocomplete
+                         partial-sql parse-result))
+                       (raw-results
+                        (duckdb-query-complete--sql-candidates
+                         sanitized-sql)))
+                  (if raw-results
+                      (let* ((word-start
+                              (save-excursion
+                                (skip-chars-backward "a-zA-Z0-9_.")
+                                (point)))
+                             (candidates
+                              (mapcar (lambda (row)
+                                        (cdr (assq 'suggestion row)))
+                                      raw-results)))
+                        (duckdb-query-complete--debug-log
+                         "SQL returning %d candidates, start=%d end=%d"
+                         (length candidates) word-start (point))
+                        (list word-start (point) candidates
+                              :exclusive 'no
+                              :company-prefix-length t
+                              :annotation-function
+                              (lambda (_)
+                                duckdb-query-complete--sql-annotation)))
+                    (duckdb-query-complete--debug-log
+                     "SQL branch: no results from DuckDB")
+                    nil))))))))))
 
 ;;;; Minor Mode
 

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -220,7 +220,7 @@ Return position after inserted reference."
       (insert ref-string)
       (point))))
 
-;;;; Value Formatting
+;;;; Internal: Value Formatting
 
 (defun duckdb-query-edit--format-value (text ref-type)
   "Format extracted TEXT as Elisp literal for REF-TYPE binding.
@@ -258,7 +258,138 @@ Return formatted string suitable for insertion as binding value."
      (format "%S" text))
     (:data
      text)))
+;;;; Internal: Detect Reference at Point
 
+(defun duckdb-query-edit--ref-at-point ()
+  "Detect @type:name reference at or around point.
+
+Return plist with :type, :name, :beg, :end if point is on a
+reference, or nil otherwise.
+
+Searches backward from point for @ character, then validates
+the reference pattern forward.  Handles cursor positioned
+anywhere within the @type:name text."
+  (save-excursion
+    (let ((orig (point))
+          (str-start (duckdb-query--in-string-p)))
+      (when str-start
+        ;; Search backward for @ within current string
+        (let ((search-start (max str-start (- orig 30))))
+          (goto-char orig)
+          (while (and (>= (point) search-start)
+                      (not (eq (char-after) ?@)))
+            (backward-char 1))
+          (when (and (eq (char-after) ?@)
+                     (looking-at "@\\(sql\\|data\\|val\\|org\\):\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
+            (let ((ref-end (match-end 0)))
+              ;; Verify original point was within the match
+              (when (and (<= (match-beginning 0) orig)
+                         (<= orig ref-end))
+                (list :type (intern (concat ":" (match-string 1)))
+                      :name (match-string 2)
+                      :beg (match-beginning 0)
+                      :end ref-end)))))))))
+
+;;;; Internal: Extract Binding Value Text
+
+(defun duckdb-query-edit--extract-binding-value (form-beg form-end keyword name)
+  "Extract the value text of binding NAME from KEYWORD parameter.
+
+FORM-BEG and FORM-END delimit the `duckdb-query' form.
+KEYWORD is :val, :sql, or :data.
+NAME is binding name as string.
+
+Walk the parameter alist structure to find the cons cell
+with NAME as car, then extract the cdr text.
+
+Return the value as a string (the Elisp literal as written in
+the buffer), or nil if binding not found.
+
+For :val with string value like \"\\\"hello\\\"\", returns the
+inner string content (without surrounding double quotes).
+For :val with numeric value like \"42\", returns \"42\".
+For :sql with value like \"\\\"SELECT ...\\\"\", returns the inner
+SQL text without surrounding double quotes."
+  (let ((param (duckdb-query-edit--find-param form-beg form-end keyword)))
+    (when param
+      (save-excursion
+        (goto-char (plist-get param :val-beg))
+        ;; Skip quote/backquote
+        (when (memq (char-after) '(?' ?`))
+          (forward-char 1))
+        ;; Enter the alist
+        (when (eq (char-after) ?\()
+          (let ((list-end (save-excursion
+                            (when (duckdb-query--forward-sexp-safe)
+                              (1- (point))))))
+            (when list-end
+              (forward-char 1)
+              (catch 'found
+                (while (< (point) list-end)
+                  (duckdb-query--skip-whitespace-and-comments)
+                  ;; Skip unquote markers
+                  (when (eq (char-after) ?,)
+                    (forward-char 1)
+                    (when (eq (char-after) ?@)
+                      (forward-char 1)))
+                  (duckdb-query--skip-whitespace-and-comments)
+                  (when (and (< (point) list-end)
+                             (eq (char-after) ?\())
+                    (let ((entry-start (point)))
+                      (forward-char 1)
+                      (duckdb-query--skip-whitespace-and-comments)
+                      (when (looking-at (regexp-quote name))
+                        (goto-char (match-end 0))
+                        (duckdb-query--skip-whitespace-and-comments)
+                        (when (eq (char-after) ?\.)
+                          (forward-char 1)
+                          (duckdb-query--skip-whitespace-and-comments)
+                          ;; Now at the value
+                          (let ((val-start (point)))
+                            (goto-char entry-start)
+                            (duckdb-query--forward-sexp-safe)
+                            ;; Back up past closing paren of entry
+                            (let ((val-text (string-trim
+                                            (buffer-substring-no-properties
+                                             val-start (1- (point))))))
+                              (throw 'found val-text)))))
+                      ;; Not this entry, skip it
+                      (goto-char entry-start)
+                      (unless (duckdb-query--forward-sexp-safe)
+                        (forward-char 1)))))))))))))
+
+(defun duckdb-query-edit--unquote-value (text ref-type)
+  "Convert binding value TEXT to inline form for REF-TYPE.
+
+TEXT is the raw Elisp literal as extracted from the buffer.
+
+For :sql, strip surrounding double quotes to get raw SQL.
+For :val, strip surrounding double quotes for strings, or
+return numeric text as-is.
+For :data, return as-is.
+
+Return string suitable for insertion into a SQL string."
+  (pcase ref-type
+    (:sql
+     (if (and (>= (length text) 2)
+              (eq (aref text 0) ?\")
+              (eq (aref text (1- (length text))) ?\"))
+         (let ((inner (substring text 1 -1)))
+           ;; Unescape escaped double quotes
+           (replace-regexp-in-string "\\\\\"" "\"" inner))
+       text))
+    (:val
+     (cond
+      ;; Elisp string literal
+      ((and (>= (length text) 2)
+            (eq (aref text 0) ?\")
+            (eq (aref text (1- (length text))) ?\"))
+       (let ((inner (substring text 1 -1)))
+         (replace-regexp-in-string "\\\\\"" "\"" inner)))
+      ;; Numeric or other literal
+      (t text)))
+    (_
+     text)))
 ;;;; Interactive: Convenience Commands
 
 ;;;###autoload

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -72,6 +72,31 @@ Uses `duckdb-query--parse-params' for structural extraction."
   (let ((params (duckdb-query--parse-params form-beg form-end)))
     (cl-find-if (lambda (p) (eq (plist-get p :key) keyword)) params)))
 
+;;;; Primitive: Locate Parameter
+
+(defun duckdb-query-edit--insert-new-param (form-end keyword name value)
+  "Insert new KEYWORD parameter with binding (NAME . VALUE).
+
+FORM-END is position after closing paren of form.
+KEYWORD is :val, :sql, or :data.
+NAME is binding name string.
+VALUE is Elisp literal string.
+
+Insert before the closing parenthesis of the `duckdb-query' form.
+Return position after inserted text."
+  (save-excursion
+    (goto-char (1- form-end))
+    (let* ((form-col (save-excursion
+                       (backward-up-list 1)
+                       (current-column)))
+           (indent (make-string (+ form-col 14) ?\s)))
+      (insert "\n" indent (symbol-name keyword)
+              " '((" name " . " value "))")
+      (point))))
+
+
+
+
 (provide 'duckdb-query-edit)
 
 ;;; duckdb-query-edit.el ends here

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -753,6 +753,65 @@ Also see `duckdb-query-edit-remove-binding'."
             (set-marker form-beg-marker nil)
             (set-marker form-end-marker nil)))))))
 
+;;;; Interactive: Remove Reference
+;;;###autoload
+(defun duckdb-query-edit-remove-binding ()
+  "Remove binding for @type:name reference at point.
+
+The reference text at point is not modified; only the
+corresponding entry in the parameter alist is deleted.
+When the entry is the last in its parameter, the entire
+parameter (keyword and value) is removed.
+
+If other references to this binding exist in the form,
+prompt for confirmation before removing.
+
+Uses `duckdb-query-edit--count-refs' to detect remaining
+references.
+Uses `duckdb-query-edit--remove-binding' for deletion.
+
+Also see `duckdb-query-edit-inline-ref' with prefix argument
+to inline and remove in one step.
+Also see `duckdb-query-edit-remove-unused-bindings' to remove
+all orphaned bindings."
+  (interactive)
+  (let ((ref (duckdb-query-edit--ref-at-point)))
+    (unless ref
+      (user-error "No @type:name reference at point"))
+    (let* ((ref-type (plist-get ref :type))
+           (ref-name (plist-get ref :name))
+           (form-bounds (duckdb-query--find-enclosing-form)))
+      (unless form-bounds
+        (user-error "Not inside a duckdb-query form"))
+      (when (eq ref-type :org)
+        (user-error "@org: references resolve from buffer context, not parameters"))
+      (let* ((form-beg (car form-bounds))
+             (form-end (cdr form-bounds))
+             (ref-count (duckdb-query-edit--count-refs
+                         form-beg form-end ref-type ref-name)))
+        ;; Warn if other references exist (count > 1 means current + others)
+        (when (and (> ref-count 1)
+                   (not (y-or-n-p
+                         (format "@%s:%s has %d references; remove binding anyway? "
+                                 (substring (symbol-name ref-type) 1)
+                                 ref-name ref-count))))
+          (user-error "Aborted"))
+        (let ((form-beg-marker (copy-marker form-beg)))
+          (unwind-protect
+              (progn
+                (unless (duckdb-query-edit--remove-binding
+                         form-beg form-end ref-type ref-name)
+                  (user-error "No binding for %s in %s parameter"
+                              ref-name (symbol-name ref-type)))
+                (indent-region (marker-position form-beg-marker)
+                               (save-excursion
+                                 (goto-char (marker-position form-beg-marker))
+                                 (forward-sexp 1)
+                                 (point)))
+                (message "Removed %s:%s binding"
+                         (substring (symbol-name ref-type) 1)
+                         ref-name))
+            (set-marker form-beg-marker nil)))))))
 
 (provide 'duckdb-query-edit)
 ;;; duckdb-query-edit.el ends here

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -186,17 +186,12 @@ KEYWORD is :val, :sql, or :data.
 NAME is binding name string.
 VALUE is Elisp literal string.
 
-Insert before the closing parenthesis of the `duckdb-query' form.
 Return position after inserted text."
   (save-excursion
     (goto-char (1- form-end))
-    (let* ((form-col (save-excursion
-                       (backward-up-list 1)
-                       (current-column)))
-           (indent (make-string (+ form-col 14) ?\s)))
-      (insert "\n" indent (symbol-name keyword)
-              " '((" name " . " value "))")
-      (point))))
+    (insert "\n" (symbol-name keyword)
+            " '((" name " . " value "))")
+    (point)))
 
 
 (provide 'duckdb-query-edit)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -374,7 +374,6 @@ branches."
        (substring text 1 -1))
     text))
 
-
 (defun duckdb-query-edit--unquote-value (text ref-type)
   "Convert binding value TEXT to inline form for REF-TYPE.
 
@@ -525,87 +524,32 @@ Return integer count."
           (while (re-search-forward pattern str-end t)
             (cl-incf count)))))
     count))
-;;;; Interactive: Convenience Commands
-
-;;;###autoload
-(defun duckdb-query-edit-extract-to-val (beg end name)
-  "Extract region BEG..END into :val parameter with NAME.
-
-Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
-REF-TYPE pre-set to :val.
-
-When called interactively, prompt only for NAME.
-
-Also see `duckdb-query-edit-extract-to-ref' for full control.
-Also see `duckdb-query-edit-extract-to-sql' for SQL fragments."
-  (interactive
-   (progn
-     (unless (duckdb-query--find-enclosing-form)
-       (user-error "Not inside a duckdb-query form"))
-     (unless (use-region-p)
-       (user-error "No active region; select text to extract"))
-     (unless (duckdb-query--in-string-p)
-       (user-error "Region must be inside a string"))
-     (let ((name (read-string "@val: name: ")))
-       (when (string-empty-p name)
-         (user-error "Binding name cannot be empty"))
-       (list (region-beginning) (region-end) name))))
-  (duckdb-query-edit-extract-to-ref beg end :val name))
-
-;;;###autoload
-(defun duckdb-query-edit-extract-to-sql (beg end name)
-  "Extract region BEG..END into :sql parameter with NAME.
-
-Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
-REF-TYPE pre-set to :sql.
-
-When called interactively, prompt only for NAME.
-
-Also see `duckdb-query-edit-extract-to-ref' for full control.
-Also see `duckdb-query-edit-extract-to-val' for literal values."
-  (interactive
-   (progn
-     (unless (duckdb-query--find-enclosing-form)
-       (user-error "Not inside a duckdb-query form"))
-     (unless (use-region-p)
-       (user-error "No active region; select text to extract"))
-     (unless (duckdb-query--in-string-p)
-       (user-error "Region must be inside a string"))
-     (let ((name (read-string "@sql: name: ")))
-       (when (string-empty-p name)
-         (user-error "Binding name cannot be empty"))
-       (list (region-beginning) (region-end) name))))
-  (duckdb-query-edit-extract-to-ref beg end :sql name))
-
-;;;###autoload
-(defun duckdb-query-edit-extract-to-data (beg end name)
-  "Extract region BEG..END into :data parameter with NAME.
-
-Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
-REF-TYPE pre-set to :data.
-
-When called interactively, prompt only for NAME.
-
-The extracted text is inserted as-is into the :data binding.
-Edit the binding value manually to provide the Elisp data
-expression.
-
-Also see `duckdb-query-edit-extract-to-ref' for full control.
-Also see `duckdb-query-edit-extract-to-val' for literal values."
-  (interactive
-   (progn
-     (unless (duckdb-query--find-enclosing-form)
-       (user-error "Not inside a duckdb-query form"))
-     (unless (use-region-p)
-       (user-error "No active region; select text to extract"))
-     (unless (duckdb-query--in-string-p)
-       (user-error "Region must be inside a string"))
-     (let ((name (read-string "@data: name: ")))
-       (when (string-empty-p name)
-         (user-error "Binding name cannot be empty"))
-       (list (region-beginning) (region-end) name))))
-  (duckdb-query-edit-extract-to-ref beg end :data name))
 ;;;; Interactive: Extract to Reference
+
+(defun duckdb-query-edit--require-region-in-string ()
+  "Validate preconditions for extraction commands.
+
+Signal `user-error' if point is not inside a `duckdb-query' form,
+no region is active, or region is not inside a string.
+
+Called by `interactive' specs of extraction commands."
+  (unless (duckdb-query--find-enclosing-form)
+    (user-error "Not inside a duckdb-query form"))
+  (unless (use-region-p)
+    (user-error "No active region; select text to extract"))
+  (unless (duckdb-query--in-string-p)
+    (user-error "Region must be inside a string")))
+
+(defun duckdb-query-edit--read-binding-name (type-str)
+  "Prompt for binding name with TYPE-STR prefix.
+
+Signal `user-error' if name is empty.
+Return name string."
+  (let ((name (read-string (format "@%s: name: " type-str))))
+    (when (string-empty-p name)
+      (user-error "Binding name cannot be empty"))
+    name))
+
 ;;;###autoload
 (defun duckdb-query-edit-extract-to-ref (beg end ref-type name)
   "Extract region BEG..END into REF-TYPE parameter with NAME.
@@ -644,21 +588,14 @@ Uses `duckdb-query-edit--insert-binding' and
 Also see `duckdb-query-edit-extract-to-val' for pre-typed variant.
 Also see `duckdb-query-edit-extract-to-sql' for pre-typed variant."
   (interactive
-   (let ((form-bounds (duckdb-query--find-enclosing-form)))
-     (unless form-bounds
-       (user-error "Not inside a duckdb-query form"))
-     (unless (use-region-p)
-       (user-error "No active region; select text to extract"))
-     (unless (duckdb-query--in-string-p)
-       (user-error "Region must be inside a string"))
+   (progn
+     (duckdb-query-edit--require-region-in-string)
      (let* ((type-str (completing-read
                        "Reference type: "
                        '("val" "sql" "data")
                        nil t))
             (ref-type (intern (concat ":" type-str)))
-            (name (read-string (format "@%s: name: " type-str))))
-       (when (string-empty-p name)
-         (user-error "Binding name cannot be empty"))
+            (name (duckdb-query-edit--read-binding-name type-str)))
        (list (region-beginning) (region-end) ref-type name))))
   (let ((form-bounds (duckdb-query--find-enclosing-form)))
     (unless form-bounds
@@ -695,6 +632,65 @@ Also see `duckdb-query-edit-extract-to-sql' for pre-typed variant."
         (set-marker end-marker nil)
         (set-marker form-beg-marker nil)
         (set-marker form-end-marker nil)))))
+
+;;;###autoload
+(defun duckdb-query-edit-extract-to-val (beg end name)
+  "Extract region BEG..END into :val parameter with NAME.
+
+Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
+REF-TYPE pre-set to :val.
+
+When called interactively, prompt only for NAME.
+
+Also see `duckdb-query-edit-extract-to-ref' for full control.
+Also see `duckdb-query-edit-extract-to-sql' for SQL fragments."
+  (interactive
+   (progn
+     (duckdb-query-edit--require-region-in-string)
+     (let ((name (duckdb-query-edit--read-binding-name "val")))
+       (list (region-beginning) (region-end) name))))
+  (duckdb-query-edit-extract-to-ref beg end :val name))
+
+;;;###autoload
+(defun duckdb-query-edit-extract-to-sql (beg end name)
+  "Extract region BEG..END into :sql parameter with NAME.
+
+Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
+REF-TYPE pre-set to :sql.
+
+When called interactively, prompt only for NAME.
+
+Also see `duckdb-query-edit-extract-to-ref' for full control.
+Also see `duckdb-query-edit-extract-to-val' for literal values."
+  (interactive
+   (progn
+     (duckdb-query-edit--require-region-in-string)
+     (let ((name (duckdb-query-edit--read-binding-name "sql")))
+       (list (region-beginning) (region-end) name))))
+  (duckdb-query-edit-extract-to-ref beg end :sql name))
+
+;;;###autoload
+(defun duckdb-query-edit-extract-to-data (beg end name)
+  "Extract region BEG..END into :data parameter with NAME.
+
+Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
+REF-TYPE pre-set to :data.
+
+When called interactively, prompt only for NAME.
+
+The extracted text is inserted as-is into the :data binding.
+Edit the binding value manually to provide the Elisp data
+expression.
+
+Also see `duckdb-query-edit-extract-to-ref' for full control.
+Also see `duckdb-query-edit-extract-to-val' for literal values."
+  (interactive
+   (progn
+     (duckdb-query-edit--require-region-in-string)
+     (let ((name (duckdb-query-edit--read-binding-name "data")))
+       (list (region-beginning) (region-end) name))))
+  (duckdb-query-edit-extract-to-ref beg end :data name))
+
 ;;;; Interactive: Inline Reference
 
 ;;;###autoload

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -58,6 +58,42 @@ context rather than inline bindings.")
     (:data . "@data:%s"))
   "Alist mapping reference types to format strings for substitution.")
 
+;;;; Customization
+
+(defcustom duckdb-query-edit-indent-after-edit nil
+  "Whether to re-indent the form after structural edits.
+
+When non-nil, run `indent-region' on the enclosing `duckdb-query'
+form after extraction, inlining, or binding removal.
+
+When nil, leave indentation unchanged.  Use this when
+`aggressive-indent-mode' or other formatting tools manage
+indentation automatically.
+
+Also see `duckdb-query-edit-extract-to-ref'.
+Also see `duckdb-query-edit-inline-ref'.
+Also see `duckdb-query-edit-remove-binding'."
+  :type 'boolean
+  :group 'duckdb-query
+  :package-version '(duckdb-query . "0.8.0"))
+
+;;;; Internal: Conditional Indentation
+
+(defun duckdb-query-edit--indent-form (form-beg-marker)
+  "Re-indent `duckdb-query' form at FORM-BEG-MARKER if enabled.
+
+Do nothing when `duckdb-query-edit-indent-after-edit' is nil.
+
+FORM-BEG-MARKER is a marker at the opening parenthesis of the form.
+Compute form end by calling `forward-sexp' from the marker position."
+  (when duckdb-query-edit-indent-after-edit
+    (indent-region (marker-position form-beg-marker)
+                   (save-excursion
+                     (goto-char (marker-position form-beg-marker))
+                     (forward-sexp 1)
+                     (point)))))
+
+
 ;;;; Internal: Locate Parameter
 
 (defun duckdb-query-edit--find-param (form-beg form-end keyword)
@@ -615,12 +651,8 @@ Also see `duckdb-query-edit-extract-to-sql' for pre-typed variant."
              (marker-position beg-marker)
              (marker-position end-marker)
              ref-type name)
-            ;; Re-indent the form
-            (indent-region (marker-position form-beg-marker)
-                           (save-excursion
-                             (goto-char (marker-position form-beg-marker))
-                             (forward-sexp 1)
-                             (point))))
+            ;; Re-indent the form IF enabled
+            (duckdb-query-edit--indent-form form-beg-marker))
         ;; Clean up markers
         (set-marker beg-marker nil)
         (set-marker end-marker nil)
@@ -744,12 +776,8 @@ Also see `duckdb-query-edit-remove-binding'."
                    (marker-position form-beg-marker)
                    (marker-position form-end-marker)
                    ref-type ref-name))
-                ;; Re-indent
-                (indent-region (marker-position form-beg-marker)
-                               (save-excursion
-                                 (goto-char (marker-position form-beg-marker))
-                                 (forward-sexp 1)
-                                 (point))))
+                ;; Re-indent IF the setting is enabled
+                (duckdb-query-edit--indent-form form-beg-marker))
             (set-marker form-beg-marker nil)
             (set-marker form-end-marker nil)))))))
 
@@ -803,11 +831,9 @@ all orphaned bindings."
                          form-beg form-end ref-type ref-name)
                   (user-error "No binding for %s in %s parameter"
                               ref-name (symbol-name ref-type)))
-                (indent-region (marker-position form-beg-marker)
-                               (save-excursion
-                                 (goto-char (marker-position form-beg-marker))
-                                 (forward-sexp 1)
-                                 (point)))
+
+                ;; Re-indent IF the setting is enabled
+                (duckdb-query-edit--indent-form form-beg-marker)
                 (message "Removed %s:%s binding"
                          (substring (symbol-name ref-type) 1)
                          ref-name))

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -193,9 +193,6 @@ Return position after inserted text."
             " '((" name " . " value "))")
     (point)))
 
-
-(provide 'duckdb-query-edit)
-
 ;;;; Internal: Replace with Reference
 
 (defun duckdb-query-edit--replace-with-ref (beg end ref-type name)
@@ -520,6 +517,7 @@ Return integer count."
           (while (re-search-forward pattern str-end t)
             (cl-incf count)))))
     count))
+
 ;;;; Interactive: Extract to Reference
 
 (defun duckdb-query-edit--require-region-in-string ()
@@ -741,4 +739,7 @@ Also see `duckdb-query-edit-extract-to-sql'."
                                  (forward-sexp 1)
                                  (point))))
             (set-marker form-beg-marker nil)))))))
+
+
+(provide 'duckdb-query-edit)
 ;;; duckdb-query-edit.el ends here

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -560,4 +560,58 @@ Also see `duckdb-query-edit-extract-to-sql' for pre-typed variant."
         (set-marker end-marker nil)
         (set-marker form-beg-marker nil)
         (set-marker form-end-marker nil)))))
+;;;; Interactive: Inline Reference
+
+;;;###autoload
+(defun duckdb-query-edit-inline-ref ()
+  "Replace @type:name reference at point with its binding value.
+
+Look up the binding value from the corresponding parameter alist
+and replace the reference text with the value.
+
+For :sql bindings, the SQL fragment text is inserted directly.
+For :val bindings, the Elisp value is unquoted for insertion.
+
+Does not remove the binding entry.  Orphaned bindings are visible
+via `duckdb-query-font-lock-mode' and can be removed manually or
+with `duckdb-query-edit-remove-binding'.
+
+Inverse of `duckdb-query-edit-extract-to-ref'.
+
+Also see `duckdb-query-edit-extract-to-val'.
+Also see `duckdb-query-edit-extract-to-sql'."
+  (interactive)
+  (let ((ref (duckdb-query-edit--ref-at-point)))
+    (unless ref
+      (user-error "No @type:name reference at point"))
+    (let* ((ref-type (plist-get ref :type))
+           (ref-name (plist-get ref :name))
+           (ref-beg (plist-get ref :beg))
+           (ref-end (plist-get ref :end))
+           (form-bounds (duckdb-query--find-enclosing-form)))
+      (unless form-bounds
+        (user-error "Not inside a duckdb-query form"))
+      (when (eq ref-type :org)
+        (user-error "@org: references resolve from buffer context, not parameters"))
+      (let* ((form-beg (car form-bounds))
+             (form-end (cdr form-bounds))
+             (raw-value (duckdb-query-edit--extract-binding-value
+                         form-beg form-end ref-type ref-name)))
+        (unless raw-value
+          (user-error "No binding for %s in %s parameter"
+                      ref-name (symbol-name ref-type)))
+        (let* ((inline-text (duckdb-query-edit--unquote-value raw-value ref-type))
+               (form-beg-marker (copy-marker form-beg)))
+          (unwind-protect
+              (progn
+                (goto-char ref-beg)
+                (delete-region ref-beg ref-end)
+                (insert inline-text)
+                ;; Re-indent
+                (indent-region (marker-position form-beg-marker)
+                               (save-excursion
+                                 (goto-char (marker-position form-beg-marker))
+                                 (forward-sexp 1)
+                                 (point))))
+            (set-marker form-beg-marker nil)))))))
 ;;; duckdb-query-edit.el ends here

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -94,6 +94,65 @@ Return position after inserted text."
               " '((" name " . " value "))")
       (point))))
 
+(defun duckdb-query-edit--find-last-binding-end (val-beg val-end)
+  "Find position after last binding entry in alist between VAL-BEG and VAL-END.
+
+Navigate into the quoted alist structure and locate the closing
+parenthesis of the last cons cell.  Return position after that
+paren, or nil if structure is not recognized.
+
+VAL-BEG is position of the quote or backquote before the alist.
+VAL-END is position after the entire value form."
+  (ignore val-end)
+  (save-excursion
+    (goto-char val-beg)
+    ;; Skip quote/backquote
+    (when (memq (char-after) '(?' ?`))
+      (forward-char 1))
+    ;; Now at opening paren of alist
+    (when (eq (char-after) ?\()
+      (let ((list-start (point))
+            (list-end (save-excursion
+                        (when (duckdb-query--forward-sexp-safe)
+                          (point)))))
+        (when list-end
+          ;; Walk forward through the alist entries to find last one
+          (goto-char list-start)
+          (forward-char 1)
+          (let ((last-entry-end nil))
+            (while (< (point) (1- list-end))
+              (duckdb-query--skip-whitespace-and-comments)
+              ;; Skip unquote markers
+              (when (eq (char-after) ?,)
+                (forward-char 1)
+                (when (eq (char-after) ?@)
+                  (forward-char 1)))
+              (duckdb-query--skip-whitespace-and-comments)
+              (when (and (< (point) (1- list-end))
+                         (duckdb-query--forward-sexp-safe))
+                (setq last-entry-end (point))))
+            last-entry-end))))))
+
+(defun duckdb-query-edit--param-indent (param)
+  "Compute indentation string for bindings inside PARAM.
+
+PARAM is plist from `duckdb-query-edit--find-param'.
+Return whitespace string matching the indentation of existing
+bindings, or reasonable default based on parameter position."
+  (save-excursion
+    (goto-char (plist-get param :val-beg))
+    ;; Skip quote/backquote and opening paren to find first binding
+    (skip-chars-forward "'`(")
+    (if (eq (char-after) ?\()
+        ;; At first binding's opening paren
+        (make-string (current-column) ?\s)
+      ;; Fallback: indent relative to keyword
+      (make-string (+ (save-excursion
+                         (goto-char (plist-get param :key-beg))
+                         (current-column))
+                       1)
+                   ?\s))))
+
 
 
 

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -72,27 +72,32 @@ Uses `duckdb-query--parse-params' for structural extraction."
   (let ((params (duckdb-query--parse-params form-beg form-end)))
     (cl-find-if (lambda (p) (eq (plist-get p :key) keyword)) params)))
 
-;;;; Primitive: Locate Parameter
+;;;; Primitive: Insert Binding
 
-(defun duckdb-query-edit--insert-new-param (form-end keyword name value)
-  "Insert new KEYWORD parameter with binding (NAME . VALUE).
+(defun duckdb-query-edit--insert-binding (form-beg form-end keyword name value)
+  "Insert binding (NAME . VALUE) into KEYWORD parameter of enclosing form.
 
-FORM-END is position after closing paren of form.
+FORM-BEG and FORM-END delimit the `duckdb-query' form.
 KEYWORD is :val, :sql, or :data.
-NAME is binding name string.
-VALUE is Elisp literal string.
+NAME is binding name as string.
+VALUE is binding value as string (Elisp literal representation).
 
-Insert before the closing parenthesis of the `duckdb-query' form.
-Return position after inserted text."
-  (save-excursion
-    (goto-char (1- form-end))
-    (let* ((form-col (save-excursion
-                       (backward-up-list 1)
-                       (current-column)))
-           (indent (make-string (+ form-col 14) ?\s)))
-      (insert "\n" indent (symbol-name keyword)
-              " '((" name " . " value "))")
-      (point))))
+If KEYWORD parameter exists, append (NAME . VALUE) to its alist.
+If KEYWORD parameter does not exist, insert it before the closing
+parenthesis of the form.
+
+For :val, VALUE is an Elisp literal (e.g., \"\\\"path/to/file\\\"\").
+For :sql, VALUE is a quoted string (e.g., \"\\\"SELECT * FROM t\\\"\").
+For :data, VALUE is an Elisp data expression.
+
+Return position after inserted text.
+
+Caller is responsible for proper VALUE formatting.
+Uses `duckdb-query-edit--find-param' for parameter location."
+  (let ((param (duckdb-query-edit--find-param form-beg form-end keyword)))
+    (if param
+        (duckdb-query-edit--append-to-param param name value)
+      (duckdb-query-edit--insert-new-param form-end keyword name value))))
 
 (defun duckdb-query-edit--find-last-binding-end (val-beg val-end)
   "Find position after last binding entry in alist between VAL-BEG and VAL-END.
@@ -133,6 +138,26 @@ VAL-END is position after the entire value form."
                 (setq last-entry-end (point))))
             last-entry-end))))))
 
+(defun duckdb-query-edit--append-to-param (param name value)
+  "Append binding (NAME . VALUE) to existing PARAM alist.
+
+PARAM is plist from `duckdb-query-edit--find-param'.
+NAME is binding name string.
+VALUE is Elisp literal string.
+
+Insert after the last binding entry in the alist.
+Return position after inserted text."
+  (let* ((val-beg (plist-get param :val-beg))
+         (val-end (plist-get param :val-end))
+         (last-end (duckdb-query-edit--find-last-binding-end val-beg val-end)))
+    (unless last-end
+      (user-error "Cannot parse parameter alist structure"))
+    (save-excursion
+      (goto-char last-end)
+      (let ((indent (duckdb-query-edit--param-indent param)))
+        (insert "\n" indent "(" name " . " value ")")
+        (point)))))
+
 (defun duckdb-query-edit--param-indent (param)
   "Compute indentation string for bindings inside PARAM.
 
@@ -153,25 +178,25 @@ bindings, or reasonable default based on parameter position."
                        1)
                    ?\s))))
 
-(defun duckdb-query-edit--append-to-param (param name value)
-  "Append binding (NAME . VALUE) to existing PARAM alist."
-  (let* ((val-beg (plist-get param :val-beg))
-         (val-end (plist-get param :val-end))
-         (last-end (duckdb-query-edit--find-last-binding-end val-beg val-end)))
-    (unless last-end
-      (user-error "Cannot parse parameter alist structure"))
-    (save-excursion
-      (goto-char last-end)
-      (let ((indent (duckdb-query-edit--param-indent param)))
-        (insert "\n" indent "(" name " . " value ")")
-        (point)))))
+(defun duckdb-query-edit--insert-new-param (form-end keyword name value)
+  "Insert new KEYWORD parameter with binding (NAME . VALUE).
 
-(defun duckdb-query-edit--insert-binding (form-beg form-end keyword name value)
-  "Insert binding (NAME . VALUE) into KEYWORD parameter of enclosing form."
-  (let ((param (duckdb-query-edit--find-param form-beg form-end keyword)))
-    (if param
-        (duckdb-query-edit--append-to-param param name value)
-      (duckdb-query-edit--insert-new-param form-end keyword name value))))
+FORM-END is position after closing paren of form.
+KEYWORD is :val, :sql, or :data.
+NAME is binding name string.
+VALUE is Elisp literal string.
+
+Insert before the closing parenthesis of the `duckdb-query' form.
+Return position after inserted text."
+  (save-excursion
+    (goto-char (1- form-end))
+    (let* ((form-col (save-excursion
+                       (backward-up-list 1)
+                       (current-column)))
+           (indent (make-string (+ form-col 14) ?\s)))
+      (insert "\n" indent (symbol-name keyword)
+              " '((" name " . " value "))")
+      (point))))
 
 
 (provide 'duckdb-query-edit)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -688,7 +688,7 @@ Also see `duckdb-query-edit-extract-to-val' for literal values."
 ;;;; Interactive: Inline Reference
 
 ;;;###autoload
-(defun duckdb-query-edit-inline-ref ()
+(defun duckdb-query-edit-inline-ref (&optional remove-binding)
   "Replace @type:name reference at point with its binding value.
 
 Look up the binding value from the corresponding parameter alist
@@ -697,15 +697,20 @@ and replace the reference text with the value.
 For :sql bindings, the SQL fragment text is inserted directly.
 For :val bindings, the Elisp value is unquoted for insertion.
 
-Does not remove the binding entry.  Orphaned bindings are visible
-via `duckdb-query-font-lock-mode' and can be removed manually or
-with `duckdb-query-edit-remove-binding'.
+With prefix argument REMOVE-BINDING (\\[universal-argument]),
+also remove the binding entry from the parameter alist.  When
+the binding is the last in its parameter, the entire parameter
+is removed.
+
+Without prefix argument, the binding entry is preserved.
+Orphaned bindings are visible via `duckdb-query-font-lock-mode'.
 
 Inverse of `duckdb-query-edit-extract-to-ref'.
 
 Also see `duckdb-query-edit-extract-to-val'.
-Also see `duckdb-query-edit-extract-to-sql'."
-  (interactive)
+Also see `duckdb-query-edit-extract-to-sql'.
+Also see `duckdb-query-edit-remove-binding'."
+  (interactive "P")
   (let ((ref (duckdb-query-edit--ref-at-point)))
     (unless ref
       (user-error "No @type:name reference at point"))
@@ -726,19 +731,27 @@ Also see `duckdb-query-edit-extract-to-sql'."
           (user-error "No binding for %s in %s parameter"
                       ref-name (symbol-name ref-type)))
         (let* ((inline-text (duckdb-query-edit--unquote-value raw-value ref-type))
-               (form-beg-marker (copy-marker form-beg)))
+               (form-beg-marker (copy-marker form-beg))
+               (form-end-marker (copy-marker form-end)))
           (unwind-protect
               (progn
                 (goto-char ref-beg)
                 (delete-region ref-beg ref-end)
                 (insert inline-text)
+                ;; Remove binding if prefix argument given
+                (when remove-binding
+                  (duckdb-query-edit--remove-binding
+                   (marker-position form-beg-marker)
+                   (marker-position form-end-marker)
+                   ref-type ref-name))
                 ;; Re-indent
                 (indent-region (marker-position form-beg-marker)
                                (save-excursion
                                  (goto-char (marker-position form-beg-marker))
                                  (forward-sexp 1)
                                  (point))))
-            (set-marker form-beg-marker nil)))))))
+            (set-marker form-beg-marker nil)
+            (set-marker form-end-marker nil)))))))
 
 
 (provide 'duckdb-query-edit)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -58,7 +58,7 @@ context rather than inline bindings.")
     (:data . "@data:%s"))
   "Alist mapping reference types to format strings for substitution.")
 
-;;;; Primitive: Locate Parameter
+;;;; Internal: Locate Parameter
 
 (defun duckdb-query-edit--find-param (form-beg form-end keyword)
   "Find KEYWORD parameter in form between FORM-BEG and FORM-END.
@@ -72,7 +72,7 @@ Uses `duckdb-query--parse-params' for structural extraction."
   (let ((params (duckdb-query--parse-params form-beg form-end)))
     (cl-find-if (lambda (p) (eq (plist-get p :key) keyword)) params)))
 
-;;;; Primitive: Insert Binding
+;;;; Internal: Insert Binding
 
 (defun duckdb-query-edit--insert-binding (form-beg form-end keyword name value)
   "Insert binding (NAME . VALUE) into KEYWORD parameter of enclosing form.

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -358,6 +358,23 @@ SQL text without surrounding double quotes."
                       (unless (duckdb-query--forward-sexp-safe)
                         (forward-char 1)))))))))))))
 
+(defun duckdb-query-edit--strip-elisp-string-quotes (text)
+  "Strip surrounding double quotes and unescape from Elisp string literal TEXT.
+
+Return inner content if TEXT is a quoted string literal.
+Return TEXT unchanged if not double-quoted.
+
+Used by `duckdb-query-edit--unquote-value' for both :sql and :val
+branches."
+  (if (and (>= (length text) 2)
+           (eq (aref text 0) ?\")
+           (eq (aref text (1- (length text))) ?\"))
+      (replace-regexp-in-string
+       "\\\\\""  "\""
+       (substring text 1 -1))
+    text))
+
+
 (defun duckdb-query-edit--unquote-value (text ref-type)
   "Convert binding value TEXT to inline form for REF-TYPE.
 
@@ -368,28 +385,14 @@ For :val, strip surrounding double quotes for strings, or
 return numeric text as-is.
 For :data, return as-is.
 
-Return string suitable for insertion into a SQL string."
+Return string suitable for insertion into a SQL string.
+
+Uses `duckdb-query-edit--strip-elisp-string-quotes' for
+double-quote stripping."
   (pcase ref-type
-    (:sql
-     (if (and (>= (length text) 2)
-              (eq (aref text 0) ?\")
-              (eq (aref text (1- (length text))) ?\"))
-         (let ((inner (substring text 1 -1)))
-           ;; Unescape escaped double quotes
-           (replace-regexp-in-string "\\\\\"" "\"" inner))
-       text))
-    (:val
-     (cond
-      ;; Elisp string literal
-      ((and (>= (length text) 2)
-            (eq (aref text 0) ?\")
-            (eq (aref text (1- (length text))) ?\"))
-       (let ((inner (substring text 1 -1)))
-         (replace-regexp-in-string "\\\\\"" "\"" inner)))
-      ;; Numeric or other literal
-      (t text)))
-    (_
-     text)))
+    ((or :sql :val) (duckdb-query-edit--strip-elisp-string-quotes text))
+    (_ text)))
+
 ;;;; Internal: Remove Binding
 
 (defun duckdb-query-edit--remove-binding (form-beg form-end keyword name)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -173,9 +173,9 @@ bindings, or reasonable default based on parameter position."
         (make-string (current-column) ?\s)
       ;; Fallback: indent relative to keyword
       (make-string (+ (save-excursion
-                         (goto-char (plist-get param :key-beg))
-                         (current-column))
-                       1)
+                        (goto-char (plist-get param :key-beg))
+                        (current-column))
+                      1)
                    ?\s))))
 
 (defun duckdb-query-edit--insert-new-param (form-end keyword name value)
@@ -201,4 +201,61 @@ Return position after inserted text."
 
 (provide 'duckdb-query-edit)
 
+;;;; Internal: Replace with Reference
+
+(defun duckdb-query-edit--replace-with-ref (beg end ref-type name)
+  "Replace text between BEG and END with @REF-TYPE:NAME reference.
+
+BEG and END delimit the text to replace (inside a string).
+REF-TYPE is :val, :sql, or :data.
+NAME is reference name string.
+
+Return position after inserted reference."
+  (let ((ref-string (format (cdr (assq ref-type
+                                       duckdb-query-edit--ref-format-alist))
+                            name)))
+    (save-excursion
+      (goto-char beg)
+      (delete-region beg end)
+      (insert ref-string)
+      (point))))
+
+;;;; Value Formatting
+
+(defun duckdb-query-edit--format-value (text ref-type)
+  "Format extracted TEXT as Elisp literal for REF-TYPE binding.
+
+TEXT is the raw string extracted from the SQL query.
+REF-TYPE is :val, :sql, or :data.
+
+For :val, strip surrounding SQL single-quotes if present and
+produce an Elisp string literal.  Numeric strings are left as
+numbers.
+
+For :sql, wrap in double quotes as Elisp string literal.
+
+For :data, return TEXT as-is (caller provides Elisp expression).
+
+Return formatted string suitable for insertion as binding value."
+  (pcase ref-type
+    (:val
+     (let ((stripped (if (and (>= (length text) 2)
+                              (eq (aref text 0) ?')
+                              (eq (aref text (1- (length text))) ?'))
+                         (substring text 1 -1)
+                       text)))
+       (cond
+        ;; Integer
+        ((string-match-p "\\`-?[0-9]+\\'" stripped)
+         stripped)
+        ;; Float
+        ((string-match-p "\\`-?[0-9]*\\.[0-9]+\\'" stripped)
+         stripped)
+        ;; String
+        (t
+         (format "%S" stripped)))))
+    (:sql
+     (format "%S" text))
+    (:data
+     text)))
 ;;; duckdb-query-edit.el ends here

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -345,8 +345,8 @@ SQL text without surrounding double quotes."
                             (duckdb-query--forward-sexp-safe)
                             ;; Back up past closing paren of entry
                             (let ((val-text (string-trim
-                                            (buffer-substring-no-properties
-                                             val-start (1- (point))))))
+                                             (buffer-substring-no-properties
+                                              val-start (1- (point))))))
                               (throw 'found val-text)))))
                       ;; Not this entry, skip it
                       (goto-char entry-start)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -470,31 +470,32 @@ whitespace on the same line."
           (setq key-beg (1- (point)))))
       (delete-region key-beg val-end))))
 
-(defun duckdb-query-edit--remove-entry (target entries)
-  "Remove TARGET entry from among ENTRIES in parameter alist.
+(defun duckdb-query-edit--remove-entry (target _entries)
+  "Remove TARGET entry from parameter alist.
 
 TARGET is plist with :name, :beg, :end.
-ENTRIES is list of all entry plists in order.
 
-Remove the entry and surrounding whitespace/newline."
+Remove the entry.  When the entry occupies its own line (only
+whitespace between line start and entry start, and between entry
+end and next newline), delete the entire line.  Otherwise delete
+only the entry text."
   (let ((entry-beg (plist-get target :beg))
         (entry-end (plist-get target :end)))
     (save-excursion
-      ;; Extend to consume surrounding whitespace and newline
       (goto-char entry-beg)
-      (let ((line-start (line-beginning-position)))
-        (skip-chars-backward " \t" line-start)
-        (when (or (eq (char-before) ?\n)
-                  (bolp))
-          (setq entry-beg (if (eq (char-before) ?\n)
-                              (1- (point))
-                            (point)))))
-      ;; Also consume trailing whitespace up to newline
-      (goto-char entry-end)
-      (skip-chars-forward " \t")
-      (when (eq (char-after) ?\n)
-        (setq entry-end (1+ (point))))
-      (delete-region entry-beg entry-end))))
+      (let* ((line-start (line-beginning-position))
+             (before-is-blank (string-blank-p
+                               (buffer-substring-no-properties
+                                line-start entry-beg))))
+        (goto-char entry-end)
+        (skip-chars-forward " \t")
+        (let ((after-is-eol (or (eolp) (eobp))))
+          (if (and before-is-blank after-is-eol)
+              ;; Entry owns the line: delete line including newline
+              (delete-region line-start
+                             (min (1+ (line-end-position)) (point-max)))
+            ;; Entry shares a line: delete just the entry
+            (delete-region entry-beg entry-end)))))))
 
 ;;;; Internal: Reference Count Check
 

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -266,25 +266,25 @@ Return formatted string suitable for insertion as binding value."
 Return plist with :type, :name, :beg, :end if point is on a
 reference, or nil otherwise.
 
-Searches backward from point for @ character, then validates
-the reference pattern forward.  Handles cursor positioned
-anywhere within the @type:name text."
+Uses `skip-chars-backward' to locate the @ trigger, then
+validates the reference pattern forward.  Handles cursor
+positioned anywhere within the @type:name text."
   (save-excursion
     (let ((orig (point))
           (str-start (duckdb-query--in-string-p)))
       (when str-start
-        ;; Search backward for @ within current string
-        (let ((search-start (max str-start (- orig 30))))
-          (goto-char orig)
-          (while (and (>= (point) search-start)
+        ;; Skip backward over characters valid in references
+        (skip-chars-backward "a-zA-Z0-9_:@" str-start)
+        ;; May have landed before @, scan forward to find it
+        (let ((search-end (min (1+ orig) (point-max))))
+          (while (and (< (point) search-end)
                       (not (eq (char-after) ?@)))
-            (backward-char 1))
+            (forward-char 1))
           (when (and (eq (char-after) ?@)
                      (looking-at "@\\(sql\\|data\\|val\\|org\\):\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
             (let ((ref-end (match-end 0)))
               ;; Verify original point was within the match
-              (when (and (<= (match-beginning 0) orig)
-                         (<= orig ref-end))
+              (when (<= orig ref-end)
                 (list :type (intern (concat ":" (match-string 1)))
                       :name (match-string 2)
                       :beg (match-beginning 0)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -153,7 +153,25 @@ bindings, or reasonable default based on parameter position."
                        1)
                    ?\s))))
 
+(defun duckdb-query-edit--append-to-param (param name value)
+  "Append binding (NAME . VALUE) to existing PARAM alist."
+  (let* ((val-beg (plist-get param :val-beg))
+         (val-end (plist-get param :val-end))
+         (last-end (duckdb-query-edit--find-last-binding-end val-beg val-end)))
+    (unless last-end
+      (user-error "Cannot parse parameter alist structure"))
+    (save-excursion
+      (goto-char last-end)
+      (let ((indent (duckdb-query-edit--param-indent param)))
+        (insert "\n" indent "(" name " . " value ")")
+        (point)))))
 
+(defun duckdb-query-edit--insert-binding (form-beg form-end keyword name value)
+  "Insert binding (NAME . VALUE) into KEYWORD parameter of enclosing form."
+  (let ((param (duckdb-query-edit--find-param form-beg form-end keyword)))
+    (if param
+        (duckdb-query-edit--append-to-param param name value)
+      (duckdb-query-edit--insert-new-param form-end keyword name value))))
 
 
 (provide 'duckdb-query-edit)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -1,0 +1,77 @@
+;;; duckdb-query-edit.el --- Editing utilities for duckdb-query forms -*- lexical-binding: t; -*-
+;;
+;; Author: Gino Cornejo <gggion123@gmail.com>
+;; Maintainer: Gino Cornejo <gggion123@gmail.com>
+;; Homepage: https://github.com/gggion/duckdb-query.el
+
+;; This file is part of duckdb-query.
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Structural editing utilities for `duckdb-query' forms.
+;;
+;; Extract inline SQL text into parameterized references:
+;;
+;;     ;; Select a region inside a query string, then:
+;;     M-x duckdb-query-edit-extract-to-ref
+;;
+;;     ;; Or bind specific types:
+;;     (define-key my-map (kbd "C-c v") #'duckdb-query-edit-extract-to-val)
+;;     (define-key my-map (kbd "C-c s") #'duckdb-query-edit-extract-to-sql)
+;;
+;; The primitives compose for programmatic use:
+;;
+;;     (duckdb-query-edit--insert-binding :val 'threshold "100")
+;;     (duckdb-query-edit--replace-with-ref beg end :val "threshold")
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'duckdb-query-parse)
+
+;;;; Reference Format Constants
+
+(defconst duckdb-query-edit--ref-types '(:val :sql :data)
+  "Reference types supported by extraction commands.
+
+Does not include :org since org references resolve from buffer
+context rather than inline bindings.")
+
+(defconst duckdb-query-edit--ref-format-alist
+  '((:val . "@val:%s")
+    (:sql . "@sql:%s")
+    (:data . "@data:%s"))
+  "Alist mapping reference types to format strings for substitution.")
+
+;;;; Primitive: Locate Parameter
+
+(defun duckdb-query-edit--find-param (form-beg form-end keyword)
+  "Find KEYWORD parameter in form between FORM-BEG and FORM-END.
+
+KEYWORD is a keyword symbol (e.g., :val, :sql, :data).
+
+Return plist with :key-beg, :key-end, :val-beg, :val-end if found.
+Return nil if KEYWORD is not present in the form.
+
+Uses `duckdb-query--parse-params' for structural extraction."
+  (let ((params (duckdb-query--parse-params form-beg form-end)))
+    (cl-find-if (lambda (p) (eq (plist-get p :key) keyword)) params)))
+
+(provide 'duckdb-query-edit)
+
+;;; duckdb-query-edit.el ends here

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -338,7 +338,7 @@ SQL text without surrounding double quotes."
                     (let ((entry-start (point)))
                       (forward-char 1)
                       (duckdb-query--skip-whitespace-and-comments)
-                      (when (looking-at (regexp-quote name))
+                      (when (looking-at (concat (regexp-quote name) "\\_>"))
                         (goto-char (match-end 0))
                         (duckdb-query--skip-whitespace-and-comments)
                         (when (eq (char-after) ?\.)

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -390,6 +390,138 @@ Return string suitable for insertion into a SQL string."
       (t text)))
     (_
      text)))
+;;;; Internal: Remove Binding
+
+(defun duckdb-query-edit--remove-binding (form-beg form-end keyword name)
+  "Remove binding NAME from KEYWORD parameter alist.
+
+FORM-BEG and FORM-END delimit the `duckdb-query' form.
+KEYWORD is :val, :sql, or :data.
+NAME is binding name as string.
+
+If this is the last binding in the parameter, remove the entire
+parameter (keyword and value) from the form.
+
+If other bindings remain, remove only the (NAME . VALUE) entry.
+
+Return non-nil if removal succeeded."
+  (let ((param (duckdb-query-edit--find-param form-beg form-end keyword)))
+    (when param
+      (save-excursion
+        (goto-char (plist-get param :val-beg))
+        ;; Skip quote/backquote
+        (when (memq (char-after) '(?' ?`))
+          (forward-char 1))
+        (when (eq (char-after) ?\()
+          (let* ((list-start (point))
+                 (list-end (save-excursion
+                             (when (duckdb-query--forward-sexp-safe)
+                               (point))))
+                 (entries nil))
+            (when list-end
+              ;; Collect all entries with their positions
+              (goto-char list-start)
+              (forward-char 1)
+              (while (< (point) (1- list-end))
+                (duckdb-query--skip-whitespace-and-comments)
+                (when (eq (char-after) ?,)
+                  (forward-char 1)
+                  (when (eq (char-after) ?@)
+                    (forward-char 1)))
+                (duckdb-query--skip-whitespace-and-comments)
+                (when (and (< (point) (1- list-end))
+                           (eq (char-after) ?\())
+                  (let ((entry-beg (point))
+                        (entry-name nil))
+                    (save-excursion
+                      (forward-char 1)
+                      (duckdb-query--skip-whitespace-and-comments)
+                      (when (looking-at "\\([a-zA-Z_][a-zA-Z0-9_-]*\\)")
+                        (setq entry-name (match-string 1))))
+                    (when (duckdb-query--forward-sexp-safe)
+                      (push (list :name entry-name
+                                  :beg entry-beg
+                                  :end (point))
+                            entries)))))
+              (setq entries (nreverse entries))
+              ;; Find target entry
+              (let ((target (cl-find-if
+                             (lambda (e) (equal (plist-get e :name) name))
+                             entries)))
+                (when target
+                  (if (= (length entries) 1)
+                      ;; Last binding: remove entire parameter
+                      (duckdb-query-edit--remove-param param)
+                    ;; Remove just the entry and surrounding whitespace
+                    (duckdb-query-edit--remove-entry target entries))
+                  t)))))))))
+
+(defun duckdb-query-edit--remove-param (param)
+  "Remove entire parameter PARAM (keyword and value) from form.
+
+PARAM is plist from `duckdb-query-edit--find-param'.
+Delete from keyword start to value end, including leading
+whitespace on the same line."
+  (let ((key-beg (plist-get param :key-beg))
+        (val-end (plist-get param :val-end)))
+    ;; Extend backward to consume leading whitespace and newline
+    (save-excursion
+      (goto-char key-beg)
+      (let ((line-start (line-beginning-position)))
+        (skip-chars-backward " \t" line-start)
+        (when (eq (char-before) ?\n)
+          (setq key-beg (1- (point)))))
+      (delete-region key-beg val-end))))
+
+(defun duckdb-query-edit--remove-entry (target entries)
+  "Remove TARGET entry from among ENTRIES in parameter alist.
+
+TARGET is plist with :name, :beg, :end.
+ENTRIES is list of all entry plists in order.
+
+Remove the entry and surrounding whitespace/newline."
+  (let ((entry-beg (plist-get target :beg))
+        (entry-end (plist-get target :end)))
+    (save-excursion
+      ;; Extend to consume surrounding whitespace and newline
+      (goto-char entry-beg)
+      (let ((line-start (line-beginning-position)))
+        (skip-chars-backward " \t" line-start)
+        (when (or (eq (char-before) ?\n)
+                  (bolp))
+          (setq entry-beg (if (eq (char-before) ?\n)
+                              (1- (point))
+                            (point)))))
+      ;; Also consume trailing whitespace up to newline
+      (goto-char entry-end)
+      (skip-chars-forward " \t")
+      (when (eq (char-after) ?\n)
+        (setq entry-end (1+ (point))))
+      (delete-region entry-beg entry-end))))
+
+;;;; Internal: Reference Count Check
+
+(defun duckdb-query-edit--count-refs (form-beg form-end ref-type name)
+  "Count occurrences of @REF-TYPE:NAME in form between FORM-BEG and FORM-END.
+
+REF-TYPE is :val, :sql, or :data.
+NAME is reference name string.
+
+Search all string literals in the form for matching references.
+
+Return integer count."
+  (let* ((type-str (substring (symbol-name ref-type) 1))
+         (pattern (format "@%s:%s\\b" (regexp-quote type-str)
+                          (regexp-quote name)))
+         (strings (duckdb-query--collect-strings-in-region form-beg form-end))
+         (count 0))
+    (save-excursion
+      (dolist (bounds strings)
+        (goto-char (1+ (car bounds)))
+        (let ((str-end (1- (cdr bounds))))
+          (while (re-search-forward pattern str-end t)
+            (cl-incf count)))))
+    count))
 ;;;; Interactive: Convenience Commands
 
 ;;;###autoload

--- a/duckdb-query-edit.el
+++ b/duckdb-query-edit.el
@@ -258,4 +258,175 @@ Return formatted string suitable for insertion as binding value."
      (format "%S" text))
     (:data
      text)))
+
+;;;; Interactive: Convenience Commands
+
+;;;###autoload
+(defun duckdb-query-edit-extract-to-val (beg end name)
+  "Extract region BEG..END into :val parameter with NAME.
+
+Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
+REF-TYPE pre-set to :val.
+
+When called interactively, prompt only for NAME.
+
+Also see `duckdb-query-edit-extract-to-ref' for full control.
+Also see `duckdb-query-edit-extract-to-sql' for SQL fragments."
+  (interactive
+   (progn
+     (unless (duckdb-query--find-enclosing-form)
+       (user-error "Not inside a duckdb-query form"))
+     (unless (use-region-p)
+       (user-error "No active region; select text to extract"))
+     (unless (duckdb-query--in-string-p)
+       (user-error "Region must be inside a string"))
+     (let ((name (read-string "@val: name: ")))
+       (when (string-empty-p name)
+         (user-error "Binding name cannot be empty"))
+       (list (region-beginning) (region-end) name))))
+  (duckdb-query-edit-extract-to-ref beg end :val name))
+
+;;;###autoload
+(defun duckdb-query-edit-extract-to-sql (beg end name)
+  "Extract region BEG..END into :sql parameter with NAME.
+
+Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
+REF-TYPE pre-set to :sql.
+
+When called interactively, prompt only for NAME.
+
+Also see `duckdb-query-edit-extract-to-ref' for full control.
+Also see `duckdb-query-edit-extract-to-val' for literal values."
+  (interactive
+   (progn
+     (unless (duckdb-query--find-enclosing-form)
+       (user-error "Not inside a duckdb-query form"))
+     (unless (use-region-p)
+       (user-error "No active region; select text to extract"))
+     (unless (duckdb-query--in-string-p)
+       (user-error "Region must be inside a string"))
+     (let ((name (read-string "@sql: name: ")))
+       (when (string-empty-p name)
+         (user-error "Binding name cannot be empty"))
+       (list (region-beginning) (region-end) name))))
+  (duckdb-query-edit-extract-to-ref beg end :sql name))
+
+;;;###autoload
+(defun duckdb-query-edit-extract-to-data (beg end name)
+  "Extract region BEG..END into :data parameter with NAME.
+
+Convenience wrapper around `duckdb-query-edit-extract-to-ref' with
+REF-TYPE pre-set to :data.
+
+When called interactively, prompt only for NAME.
+
+The extracted text is inserted as-is into the :data binding.
+Edit the binding value manually to provide the Elisp data
+expression.
+
+Also see `duckdb-query-edit-extract-to-ref' for full control.
+Also see `duckdb-query-edit-extract-to-val' for literal values."
+  (interactive
+   (progn
+     (unless (duckdb-query--find-enclosing-form)
+       (user-error "Not inside a duckdb-query form"))
+     (unless (use-region-p)
+       (user-error "No active region; select text to extract"))
+     (unless (duckdb-query--in-string-p)
+       (user-error "Region must be inside a string"))
+     (let ((name (read-string "@data: name: ")))
+       (when (string-empty-p name)
+         (user-error "Binding name cannot be empty"))
+       (list (region-beginning) (region-end) name))))
+  (duckdb-query-edit-extract-to-ref beg end :data name))
+;;;; Interactive: Extract to Reference
+;;;###autoload
+(defun duckdb-query-edit-extract-to-ref (beg end ref-type name)
+  "Extract region BEG..END into REF-TYPE parameter with NAME.
+
+Replace selected text with @REF-TYPE:NAME reference and insert
+corresponding binding into the parameter alist.
+
+When called interactively with active region inside a `duckdb-query'
+SQL string, prompt for REF-TYPE and NAME.
+
+REF-TYPE is :val, :sql, or :data.
+NAME is binding name string.
+
+The extracted text is formatted appropriately for the target
+parameter type:
+
+  :val - SQL quotes stripped, stored as Elisp literal
+  :sql - Stored as Elisp string
+  :data - Stored as-is (for manual editing)
+
+Uses markers to track region positions across buffer modifications,
+ensuring correct replacement regardless of where the binding is
+inserted relative to the region.
+
+Example workflow:
+
+  ;; Given:
+  (duckdb-query \"SELECT * FROM \\='./data/users.csv\\='\")
+
+  ;; Select \\='./data/users.csv\\=', invoke with :val and \"csv_path\":
+  (duckdb-query \"SELECT * FROM @val:csv_path\"
+                :val \\='((csv_path . \"./data/users.csv\")))
+
+Uses `duckdb-query-edit--insert-binding' and
+`duckdb-query-edit--replace-with-ref'.
+Also see `duckdb-query-edit-extract-to-val' for pre-typed variant.
+Also see `duckdb-query-edit-extract-to-sql' for pre-typed variant."
+  (interactive
+   (let ((form-bounds (duckdb-query--find-enclosing-form)))
+     (unless form-bounds
+       (user-error "Not inside a duckdb-query form"))
+     (unless (use-region-p)
+       (user-error "No active region; select text to extract"))
+     (unless (duckdb-query--in-string-p)
+       (user-error "Region must be inside a string"))
+     (let* ((type-str (completing-read
+                       "Reference type: "
+                       '("val" "sql" "data")
+                       nil t))
+            (ref-type (intern (concat ":" type-str)))
+            (name (read-string (format "@%s: name: " type-str))))
+       (when (string-empty-p name)
+         (user-error "Binding name cannot be empty"))
+       (list (region-beginning) (region-end) ref-type name))))
+  (let ((form-bounds (duckdb-query--find-enclosing-form)))
+    (unless form-bounds
+      (user-error "Not inside a duckdb-query form"))
+    (let* ((text (buffer-substring-no-properties beg end))
+           (value (duckdb-query-edit--format-value text ref-type))
+           ;; Use markers to survive buffer modifications
+           (beg-marker (copy-marker beg))
+           (end-marker (copy-marker end))
+           (form-beg-marker (copy-marker (car form-bounds)))
+           (form-end-marker (copy-marker (cdr form-bounds))))
+      (unwind-protect
+          (progn
+            ;; Insert binding first.  Markers track region positions
+            ;; automatically regardless of insertion location.
+            (duckdb-query-edit--insert-binding
+             (marker-position form-beg-marker)
+             (marker-position form-end-marker)
+             ref-type name value)
+            ;; Replace original text with reference.  Markers have
+            ;; adjusted for any text inserted before the region.
+            (duckdb-query-edit--replace-with-ref
+             (marker-position beg-marker)
+             (marker-position end-marker)
+             ref-type name)
+            ;; Re-indent the form
+            (indent-region (marker-position form-beg-marker)
+                           (save-excursion
+                             (goto-char (marker-position form-beg-marker))
+                             (forward-sexp 1)
+                             (point))))
+        ;; Clean up markers
+        (set-marker beg-marker nil)
+        (set-marker end-marker nil)
+        (set-marker form-beg-marker nil)
+        (set-marker form-end-marker nil)))))
 ;;; duckdb-query-edit.el ends here

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -43,7 +43,7 @@
 ;; Highlighted reference types:
 ;; - @org:table-name - Org table references
 ;; - @data:name - Elisp data bindings
-;; - @var:name - SQL variable literals
+;; - @val:name - SQL variable literals
 ;; - @expr:name - SQL expression bindings
 
 ;;; Code:
@@ -227,7 +227,7 @@ PRESET is a symbol from `duckdb-query-font-lock-presets'."
   "`duckdb-query' Functions whose first string argument is a SQL query.")
 
 (defconst duckdb-query-font-lock--reference-regexp
-  (rx (group "@" (or "org" "data" "var" "expr" "sql") ":")
+  (rx (group "@" (or "org" "data" "val" "expr" "sql") ":")
       (group (any "a-zA-Z_") (* (any "a-zA-Z0-9_:/-"))))
   "Regexp matching @type:name references.
 Group 1: @type: prefix.
@@ -236,8 +236,8 @@ Group 2: name.
 Reference types:
 - org:  Org table references via `org-babel-ref-resolve'
 - data: Elisp data bindings from :data parameter
-- var:  SQL variable literals from :var parameter
-- expr: SQL expressions from :var parameter
+- val:  SQL variable literals from :val parameter
+- expr: SQL expressions from :expr parameter
 - sql:  SQL string fragments for query construction")
 
 (defun duckdb-query-font-lock--in-quoted-context-p ()
@@ -303,7 +303,7 @@ Reference types:
 (define-minor-mode duckdb-query-font-lock-mode
   "Minor mode for highlighting @type:name references in duckdb-query strings.
 
-When enabled, references like @org:table, @data:name, @var:value,
+When enabled, references like @org:table, @data:name, @val:value,
 and @expr:query are highlighted within SQL string arguments to
 `duckdb-query' and related functions.
 

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -1,0 +1,319 @@
+;;; duckdb-query-font-lock.el --- Font-lock for duckdb-query SQL strings -*- lexical-binding: t; -*-
+
+;; Author: Gino Cornejo <gggion123@gmail.com>
+;; Maintainer: Gino Cornejo <gggion123@gmail.com>
+;; Homepage: https://github.com/gggion/duckdb-query.el
+
+;; This file is part of duckdb-query.
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provides font-lock highlighting for @type:name references within
+;; duckdb-query SQL strings.
+;;
+;; Basic usage:
+;;
+;;     (add-hook 'emacs-lisp-mode-hook #'duckdb-query-font-lock-mode)
+;;
+;; For Org src blocks, the above hook is sufficient since Org's native
+;; fontification uses `emacs-lisp-mode' internally.  Optionally, also
+;; enable in Org buffers directly:
+;;
+;;     (add-hook 'org-mode-hook #'duckdb-query-font-lock-mode)
+;;
+;; Select a highlighting preset interactively:
+;;
+;;     M-x duckdb-query-font-lock-select-preset
+;;
+;; Highlighted reference types:
+;; - @org:table-name - Org table references
+;; - @data:name - Elisp data bindings
+;; - @var:name - SQL variable literals
+;; - @expr:name - SQL expression bindings
+
+;;; Code:
+
+(require 'font-lock)
+
+(defgroup duckdb-query-font-lock nil
+  "Font-lock support for duckdb-query SQL strings."
+  :group 'duckdb-query
+  :prefix "duckdb-query-font-lock-")
+
+;;;; Faces
+
+(defface duckdb-query-reference-prefix-face
+  '((t :inherit shadow))
+  "Face for @type: prefix in duckdb-query references."
+  :group 'duckdb-query-font-lock)
+
+(defface duckdb-query-reference-name-face
+  '((t :inherit font-lock-constant-face :weight bold))
+  "Face for the name portion of @type:name references."
+  :group 'duckdb-query-font-lock)
+
+;;;; Presets
+
+(defvar duckdb-query-font-lock-presets
+  '((shadow-bold-constant
+     :prefix (:inherit shadow)
+     :name (:inherit font-lock-constant-face :weight bold))
+
+    (shadow-bold-variable
+     :prefix (:inherit shadow)
+     :name (:inherit font-lock-variable-name-face :weight bold))
+
+    (keyword-variable
+     :prefix (:inherit font-lock-keyword-face)
+     :name (:inherit font-lock-variable-name-face :weight bold))
+
+    (uniform-type
+     :prefix (:inherit font-lock-type-face)
+     :name (:inherit font-lock-type-face))
+
+    (uniform-keyword
+     :prefix (:inherit font-lock-keyword-face)
+     :name (:inherit font-lock-keyword-face))
+
+    (italic-shadow-bold-constant
+     :prefix (:inherit shadow :slant italic)
+     :name (:inherit font-lock-constant-face :weight bold))
+
+    (light-extra-bold
+     :prefix (:inherit font-lock-constant-face :weight light)
+     :name (:inherit font-lock-constant-face :weight extra-bold))
+
+    (shadow-completions
+     :prefix (:inherit shadow)
+     :name (:inherit completions-common-part :weight bold))
+
+    (italic-shadow-bold-underline
+     :prefix (:inherit shadow :slant italic)
+     :name (:inherit font-lock-constant-face :weight bold :underline t)))
+  "Alist of highlighting presets for duckdb-query references.
+Each entry is (NAME :prefix PLIST :name PLIST).")
+
+(defcustom duckdb-query-font-lock-preset 'shadow-bold-constant
+  "Current highlighting preset for duckdb-query references.
+Use `duckdb-query-font-lock-select-preset' to change interactively."
+  :type `(choice ,@(mapcar (lambda (p) `(const ,(car p)))
+                           duckdb-query-font-lock-presets))
+  :group 'duckdb-query-font-lock
+  :set (lambda (sym val)
+         (set-default sym val)
+         (when (fboundp 'duckdb-query-font-lock-apply-preset)
+           (duckdb-query-font-lock-apply-preset val))))
+
+;;;; Preset Application
+
+(defun duckdb-query-font-lock-apply-preset (preset)
+  "Apply PRESET to duckdb-query reference faces.
+PRESET is a symbol naming an entry in `duckdb-query-font-lock-presets'."
+  (let ((entry (assq preset duckdb-query-font-lock-presets)))
+    (unless entry
+      (error "Unknown preset: %s" preset))
+    (let ((prefix-attrs (plist-get (cdr entry) :prefix))
+          (name-attrs (plist-get (cdr entry) :name)))
+      ;; Reset faces
+      (set-face-attribute 'duckdb-query-reference-prefix-face nil
+                          :inherit nil :weight 'normal :slant 'normal
+                          :underline nil :foreground 'unspecified
+                          :background 'unspecified :box nil)
+      (set-face-attribute 'duckdb-query-reference-name-face nil
+                          :inherit nil :weight 'normal :slant 'normal
+                          :underline nil :foreground 'unspecified
+                          :background 'unspecified :box nil)
+      ;; Apply new attributes
+      (apply #'set-face-attribute 'duckdb-query-reference-prefix-face nil
+             prefix-attrs)
+      (apply #'set-face-attribute 'duckdb-query-reference-name-face nil
+             name-attrs)
+      ;; Refontify buffers with mode enabled
+      (dolist (buf (buffer-list))
+        (with-current-buffer buf
+          (when (bound-and-true-p duckdb-query-font-lock-mode)
+            (font-lock-flush)))))))
+
+;;;; Preset Selection
+
+(defvar duckdb-query-font-lock--select-history nil
+  "Minibuffer history for `duckdb-query-font-lock-select-preset'.")
+
+(defvar duckdb-query-font-lock--saved-preset nil
+  "Saved preset for restoration on cancel.")
+
+(defvar duckdb-query-font-lock--last-previewed nil
+  "Last previewed preset to avoid redundant applications.")
+
+(defun duckdb-query-font-lock--preview-preset ()
+  "Preview the currently selected preset in minibuffer."
+  (when (minibufferp)
+    (when-let* ((candidate (or
+                            ;; Vertico
+                            (and (bound-and-true-p vertico--index)
+                                 (bound-and-true-p vertico--candidates)
+                                 (>= vertico--index 0)
+                                 (nth vertico--index vertico--candidates))
+                            ;; Icomplete
+                            (and (bound-and-true-p icomplete-mode)
+                                 (car completion-all-sorted-completions))
+                            ;; Standard completion
+                            (let ((c (minibuffer-contents-no-properties)))
+                              (when (assq (intern-soft c)
+                                          duckdb-query-font-lock-presets)
+                                c))))
+                (preset (intern-soft candidate))
+                ((assq preset duckdb-query-font-lock-presets))
+                ((not (eq preset duckdb-query-font-lock--last-previewed))))
+      (setq duckdb-query-font-lock--last-previewed preset)
+      (duckdb-query-font-lock-apply-preset preset))))
+
+(defun duckdb-query-font-lock--setup-preview ()
+  "Setup preview hooks in minibuffer."
+  (setq duckdb-query-font-lock--last-previewed nil)
+  (add-hook 'post-command-hook #'duckdb-query-font-lock--preview-preset nil t))
+
+;;;###autoload
+(defun duckdb-query-font-lock-select-preset (preset)
+  "Select a highlighting PRESET with live preview.
+Interactively, show completion with preview as you navigate
+candidates.  Works with `vertico', `icomplete', `fido-mode', and
+standard completion.
+
+PRESET is a symbol from `duckdb-query-font-lock-presets'."
+  (interactive
+   (let ((duckdb-query-font-lock--saved-preset duckdb-query-font-lock-preset)
+         (selected nil))
+     (minibuffer-with-setup-hook #'duckdb-query-font-lock--setup-preview
+       (unwind-protect
+           (setq selected
+                 (intern
+                  (completing-read
+                   (format-prompt "Preset" duckdb-query-font-lock-preset)
+                   (mapcar (lambda (p) (symbol-name (car p)))
+                           duckdb-query-font-lock-presets)
+                   nil t nil
+                   'duckdb-query-font-lock--select-history
+                   (symbol-name duckdb-query-font-lock-preset))))
+         ;; On C-g, restore saved preset
+         (unless selected
+           (duckdb-query-font-lock-apply-preset
+            duckdb-query-font-lock--saved-preset))))
+     (list selected)))
+  (when preset
+    (setq duckdb-query-font-lock-preset preset)
+    (duckdb-query-font-lock-apply-preset preset)
+    (message "Applied preset: %s" preset)))
+
+;;;; Font-lock Implementation
+
+(defconst duckdb-query-font-lock--query-functions
+  '(duckdb-query)
+  "`duckdb-query' Functions whose first string argument is a SQL query.")
+
+(defconst duckdb-query-font-lock--reference-regexp
+  "\\(@\\(?:org\\|data\\|var\\|expr\\):\\)\\([a-zA-Z_][a-zA-Z0-9_:/-]*\\)"
+  "Regexp matching @type:name references.
+Group 1: @type: prefix.
+Group 2: name.")
+
+(defun duckdb-query-font-lock--in-quoted-context-p ()
+  "Return non-nil if point is inside a quoted form."
+  (save-excursion
+    (catch 'quoted
+      (while (let ((paren-pos (nth 1 (syntax-ppss))))
+               (when paren-pos
+                 (goto-char paren-pos)
+                 (when (memq (char-before) '(?\' ?\`))
+                   (throw 'quoted t))
+                 (when (looking-at "([ \t\n]*quote\\_>")
+                   (throw 'quoted t))
+                 t)))
+      nil)))
+
+(defun duckdb-query-font-lock--in-duckdb-query-string-p (pos)
+  "Return non-nil if POS is inside a duckdb-query SQL string."
+  (save-excursion
+    (goto-char pos)
+    (let ((ppss (syntax-ppss)))
+      (when (and (nth 3 ppss)
+                 (not (nth 4 ppss)))
+        (let ((string-start (nth 8 ppss)))
+          (goto-char string-start)
+          (unless (duckdb-query-font-lock--in-quoted-context-p)
+            (let ((paren-pos (nth 1 (syntax-ppss))))
+              (when paren-pos
+                (goto-char paren-pos)
+                (forward-char 1)
+                (skip-chars-forward " \t\n")
+                (and (looking-at "\\_<\\(duckdb-query[-a-z]*\\)\\_>")
+                     (memq (intern (match-string 1))
+                           duckdb-query-font-lock--query-functions)
+                     (progn
+                       (goto-char (match-end 0))
+                       (skip-chars-forward " \t\n")
+                       (= (point) string-start)))))))))))
+
+(defun duckdb-query-font-lock--fontify-references (limit)
+  "Fontify @type:name references up to LIMIT."
+  (let ((found nil))
+    (while (re-search-forward duckdb-query-font-lock--reference-regexp limit t)
+      (let ((prefix-beg (match-beginning 1))
+            (prefix-end (match-end 1))
+            (name-beg (match-beginning 2))
+            (name-end (match-end 2)))
+        (when (duckdb-query-font-lock--in-duckdb-query-string-p prefix-beg)
+          (setq found t)
+          (add-face-text-property prefix-beg prefix-end
+                                  'duckdb-query-reference-prefix-face)
+          (add-face-text-property name-beg name-end
+                                  'duckdb-query-reference-name-face))))
+    found))
+
+(defconst duckdb-query-font-lock-keywords
+  '((duckdb-query-font-lock--fontify-references))
+  "Font-lock keywords for duckdb-query references.")
+
+;;;; Minor Mode
+
+;;;###autoload
+(define-minor-mode duckdb-query-font-lock-mode
+  "Minor mode for highlighting @type:name references in duckdb-query strings.
+
+When enabled, references like @org:table, @data:name, @var:value,
+and @expr:query are highlighted within SQL string arguments to
+`duckdb-query' and related functions.
+
+To enable globally:
+
+    (add-hook \\='emacs-lisp-mode-hook #\\='duckdb-query-font-lock-mode)
+
+Use `duckdb-query-font-lock-select-preset' to change highlighting
+style interactively with live preview."
+  :lighter " DQ"
+  :group 'duckdb-query-font-lock
+  (if duckdb-query-font-lock-mode
+      (progn
+        (duckdb-query-font-lock-apply-preset duckdb-query-font-lock-preset)
+        (font-lock-add-keywords nil duckdb-query-font-lock-keywords 'append))
+    (font-lock-remove-keywords nil duckdb-query-font-lock-keywords))
+  (font-lock-flush))
+
+(provide 'duckdb-query-font-lock)
+
+;;; duckdb-query-font-lock.el ends here

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -44,7 +44,6 @@
 ;; - @org:table-name - Org table references
 ;; - @data:name - Elisp data bindings
 ;; - @val:name - SQL variable literals
-;; - @expr:name - SQL expression bindings
 
 ;;; Code:
 
@@ -227,7 +226,7 @@ PRESET is a symbol from `duckdb-query-font-lock-presets'."
   "`duckdb-query' Functions whose first string argument is a SQL query.")
 
 (defconst duckdb-query-font-lock--reference-regexp
-  (rx (group "@" (or "org" "data" "val" "expr" "sql") ":")
+  (rx (group "@" (or "org" "data" "val" "sql") ":")
       (group (any "a-zA-Z_") (* (any "a-zA-Z0-9_:/-"))))
   "Regexp matching @type:name references.
 Group 1: @type: prefix.
@@ -237,7 +236,6 @@ Reference types:
 - org:  Org table references via `org-babel-ref-resolve'
 - data: Elisp data bindings from :data parameter
 - val:  SQL variable literals from :val parameter
-- expr: SQL expressions from :expr parameter
 - sql:  SQL string fragments for query construction")
 
 (defun duckdb-query-font-lock--in-quoted-context-p ()

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -39,15 +39,21 @@
 ;; - @val:name   SQL variable literals
 ;; - @sql:name   SQL fragment substitution
 ;;
-;; Invalid references (e.g., @sql: inside (sql ...) wrapper) use
+;; Invalid references (undefined bindings or invalid context) use
 ;; `duckdb-query-reference-invalid-face' to signal resolution failure.
 ;;
+;; Uses `duckdb-query-parse.el' for structural parsing.
 ;; Also see `duckdb-query' for reference syntax documentation.
 
 ;;; Code:
 
 (require 'font-lock)
 (require 'cl-lib)
+(require 'duckdb-query-parse)
+
+;; Defined by font-lock, bound when `font-lock-extend-region-functions' run.
+(defvar font-lock-beg)
+(defvar font-lock-end)
 
 (defgroup duckdb-query-font-lock nil
   "Font-lock support for `duckdb-query' SQL strings."
@@ -60,10 +66,10 @@
   '((t :inherit shadow))
   "Face for @type: prefix in `duckdb-query' references.
 
-Applied by `duckdb-query-font-lock--fontify-references' to the
-prefix portion of valid references (e.g., \"@val:\" in \"@val:name\").
+Applied to the prefix portion of valid references.
 
-Customized via `duckdb-query-font-lock-preset' or directly."
+Customized via `duckdb-query-font-lock-preset' or directly.
+Also see `duckdb-query-reference-name-face' for the name portion."
   :group 'duckdb-query-font-lock
   :package-version '(duckdb-query . "0.7.0"))
 
@@ -71,24 +77,22 @@ Customized via `duckdb-query-font-lock-preset' or directly."
   '((t :inherit font-lock-constant-face :weight bold))
   "Face for the name portion of @type:name references.
 
-Applied by `duckdb-query-font-lock--fontify-references' to the
-name portion of valid references (e.g., \"name\" in \"@val:name\").
+Applied to the name portion of valid references.
 
-Customized via `duckdb-query-font-lock-preset' or directly."
+Customized via `duckdb-query-font-lock-preset' or directly.
+Also see `duckdb-query-reference-prefix-face' for the prefix portion."
   :group 'duckdb-query-font-lock
   :package-version '(duckdb-query . "0.7.0"))
 
 (defface duckdb-query-reference-invalid-face
   '((t :inherit warning :weight bold))
-  "Face for references in semantically invalid positions.
+  "Face for invalid references.
 
-Applied to @sql: and @org: references inside (sql ...) wrappers,
-where substitution order prevents their resolution.  The @sql:
-substitution occurs before @val: processing, so @sql: references
-in (sql ...) expressions remain as literal text and cause parser
-errors.
+Applied to references that cannot be resolved:
+- @sql: or @org: inside (sql ...) wrappers in :val bindings
+- References to undefined binding names
 
-Also see `duckdb-query--substitute-sql-refs' for substitution order."
+Also see `duckdb-query--validate-reference' for validation rules."
   :group 'duckdb-query-font-lock
   :package-version '(duckdb-query . "0.7.0"))
 
@@ -162,11 +166,11 @@ with live preview."
 
 PRESET is a symbol naming an entry in `duckdb-query-font-lock-presets'.
 
-Resets face attributes before applying new values.  Triggers
+Reset face attributes before applying new values.  Trigger
 `font-lock-flush' in all buffers with `duckdb-query-font-lock-mode'.
 
-Called by `duckdb-query-font-lock-select-preset' and the :set
-function of `duckdb-query-font-lock-preset'."
+Called by `duckdb-query-font-lock-select-preset'.
+Also see the :set function of `duckdb-query-font-lock-preset'."
   (let ((entry (assq preset duckdb-query-font-lock-presets)))
     (unless entry
       (error "Unknown preset: %s" preset))
@@ -206,14 +210,14 @@ minibuffer.  Restored if user cancels with \\[keyboard-quit].")
 (defvar duckdb-query-font-lock--last-previewed nil
   "Last previewed preset to avoid redundant applications.
 
-Compared against current candidate in `duckdb-query-font-lock--preview-preset'
-to prevent re-applying the same preset on every keystroke.")
+Compared against current candidate by
+`duckdb-query-font-lock--preview-preset'.")
 
 (defun duckdb-query-font-lock--preview-preset ()
   "Preview the currently selected preset in minibuffer.
 
-Extracts current candidate from vertico, icomplete, or standard
-completion and applies it via `duckdb-query-font-lock-apply-preset'.
+Extract current candidate from vertico, icomplete, or standard
+completion and apply it via `duckdb-query-font-lock-apply-preset'.
 
 Called by `post-command-hook' in minibuffer during preset selection."
   (when (minibufferp)
@@ -238,9 +242,9 @@ Called by `post-command-hook' in minibuffer during preset selection."
       (duckdb-query-font-lock-apply-preset preset))))
 
 (defun duckdb-query-font-lock--setup-preview ()
-  "Setup preview hooks in minibuffer.
+  "Install preview hook in minibuffer.
 
-Installs `duckdb-query-font-lock--preview-preset' on `post-command-hook'
+Add `duckdb-query-font-lock--preview-preset' to `post-command-hook'
 for live preview during `duckdb-query-font-lock-select-preset'."
   (setq duckdb-query-font-lock--last-previewed nil)
   (add-hook 'post-command-hook #'duckdb-query-font-lock--preview-preset nil t))
@@ -250,7 +254,7 @@ for live preview during `duckdb-query-font-lock-select-preset'."
   "Select a highlighting PRESET with live preview.
 
 Interactively, show completion with preview as you navigate
-candidates.  Works with vertico, icomplete, fido-mode, and
+candidates.  Works with `vertico', `icomplete', `fido-mode', and
 standard completion.
 
 PRESET is a symbol from `duckdb-query-font-lock-presets'.
@@ -282,281 +286,172 @@ Also see `duckdb-query-font-lock-preset' for programmatic access."
     (duckdb-query-font-lock-apply-preset preset)
     (message "Applied preset: %s" preset)))
 
-;;;; Context Detection
+;;;; Fontification Engine
+;;;;; Face Application
 
-(defconst duckdb-query-font-lock--query-functions
-  '(duckdb-query duckdb-query-value duckdb-query-row duckdb-query-column)
-  "Functions whose first string argument is a SQL query.
+(defun duckdb-query-font-lock--compute-prefix-end (ref-beg ref-type)
+  "Compute end position of @type: prefix starting at REF-BEG.
 
-Used by `duckdb-query-font-lock--find-duckdb-query-form' to identify
-forms containing highlightable references.")
+REF-TYPE is the reference type symbol (sql, data, val, org).
+Returns position after the colon in the @type: prefix.
 
-(defconst duckdb-query-font-lock--reference-regexp
-  (rx (group "@" (or "org" "data" "val" "sql") ":")
-      (group (any "a-zA-Z_") (* (any "a-zA-Z0-9_:/-"))))
-  "Regexp matching @type:name references.
+Called by `duckdb-query-font-lock--apply-reference-face'."
+  (+ ref-beg 1 (length (symbol-name ref-type)) 1))
 
-Group 1: @type: prefix.
-Group 2: name.
+(defun duckdb-query-font-lock--apply-reference-face (ref invalid-p)
+  "Apply face to reference REF.
 
-Used by `duckdb-query-font-lock--fontify-references'.")
+REF is a plist with :type, :name, :beg, :end keys from
+`duckdb-query--find-references-in-string'.
+INVALID-P is non-nil if the reference failed validation.
 
-(defun duckdb-query-font-lock--find-duckdb-query-form ()
-  "Find the containing `duckdb-query' form if point is inside one.
+Apply `duckdb-query-reference-invalid-face' to entire reference
+when INVALID-P is non-nil.  Otherwise apply prefix and name faces
+to their respective portions.
 
-Return (FORM-START . FORM-END) if found, nil otherwise.
+Called by `duckdb-query-font-lock--fontify-form'."
+  (let ((ref-beg (plist-get ref :beg))
+        (ref-end (plist-get ref :end))
+        (ref-type (plist-get ref :type)))
+    (if invalid-p
+        (font-lock-prepend-text-property
+         ref-beg ref-end 'face 'duckdb-query-reference-invalid-face)
+      (let ((prefix-end (duckdb-query-font-lock--compute-prefix-end
+                         ref-beg ref-type)))
+        (font-lock-prepend-text-property
+         ref-beg prefix-end 'face 'duckdb-query-reference-prefix-face)
+        (font-lock-prepend-text-property
+         prefix-end ref-end 'face 'duckdb-query-reference-name-face)))))
 
-Traverses upward through sexp structure, checking each containing
-list for a `duckdb-query' family function at its head.  Handles
-quoted data structures correctly.
+;;;;; Form Fontification
 
-Called by `duckdb-query-font-lock--fontify-references'."
-  (save-excursion
-    (let ((depth 0))
-      (catch 'found
-        (while (< depth 50)  ; Safety limit
-          (let ((paren-pos (nth 1 (syntax-ppss))))
-            (unless paren-pos
-              (throw 'found nil))
-            (goto-char paren-pos)
-            (cl-incf depth)
-            ;; Check if this paren starts a duckdb-query call
-            (save-excursion
-              (forward-char 1)
-              (skip-chars-forward " \t\n")
-              (when (looking-at "\\_<\\(duckdb-query[-a-z]*\\)\\_>")
-                (let ((func-name (intern (match-string 1))))
-                  (when (memq func-name duckdb-query-font-lock--query-functions)
-                    ;; Verify not quoted at top level
-                    (goto-char paren-pos)
-                    (let ((outer-paren (nth 1 (syntax-ppss))))
-                      (when (or outer-paren
-                                (not (memq (char-before paren-pos) '(?\' ?\`))))
-                        (goto-char paren-pos)
-                        (forward-sexp 1)
-                        (throw 'found (cons paren-pos (point)))))))))))))))
+(defun duckdb-query-font-lock--fontify-form (parse-result)
+  "Fontify all references in PARSE-RESULT.
 
-(defun duckdb-query-font-lock--inside-sql-wrapper-p (pos)
-  "Return non-nil if POS is inside a (sql ...) wrapper.
+PARSE-RESULT is a `duckdb-query-parse-result' struct from
+`duckdb-query--parse-at-point'.
 
-Checks parent sexps for a list starting with symbol `sql'.
+Validate all references via `duckdb-query--validate-all-references'
+and apply appropriate faces based on validity status.
 
-Called by `duckdb-query-font-lock--context-at-pos'."
-  (save-excursion
-    (goto-char pos)
-    (let ((depth 0))
-      (catch 'found
-        (while (< depth 20)  ; Safety limit
-          (let ((paren-pos (nth 1 (syntax-ppss))))
-            (unless paren-pos
-              (throw 'found nil))
-            (goto-char paren-pos)
-            (when (looking-at "([ \t\n]*sql\\_>")
-              (throw 'found t))
-            (cl-incf depth)))
-        nil))))
+Called by `duckdb-query-font-lock--propertize'."
+  (let* ((references (duckdb-query-parse-result-references parse-result))
+         (invalid-refs (duckdb-query--validate-all-references parse-result))
+         (invalid-positions (make-hash-table :test 'eq)))
+    (dolist (entry invalid-refs)
+      (puthash (plist-get (car entry) :beg) t invalid-positions))
+    (dolist (ref references)
+      (duckdb-query-font-lock--apply-reference-face
+       ref (gethash (plist-get ref :beg) invalid-positions)))))
 
-(defun duckdb-query-font-lock--in-sql-param-p (pos form-bounds)
-  "Return non-nil if POS is inside a :sql parameter value in FORM-BOUNDS.
+;;;;; Form Detection
 
-FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
+(defun duckdb-query-font-lock--find-form-start (pos)
+  "Find start of `duckdb-query' form containing POS.
 
-Called by `duckdb-query-font-lock--context-at-pos'."
-  (save-excursion
-    (let ((form-start (car form-bounds))
-          (form-end (cdr form-bounds)))
-      (goto-char form-start)
-      (forward-char 1)
-      (skip-chars-forward " \t\n")
-      ;; Skip function name
-      (forward-sexp 1)
-      ;; Parse keyword arguments
-      (catch 'done
-        (while (< (point) form-end)
-          (skip-chars-forward " \t\n")
-          (when (>= (point) form-end)
-            (throw 'done nil))
-          (cond
-           ;; Keyword argument
-           ((eq (char-after) ?:)
-            (let ((kw-start (point)))
-              (forward-sexp 1)
-              (let ((keyword (buffer-substring-no-properties kw-start (point))))
-                (skip-chars-forward " \t\n")
-                (let ((val-start (point)))
-                  (condition-case nil
-                      (progn
-                        (forward-sexp 1)
-                        (when (string= keyword ":sql")
-                          (when (and (>= pos val-start)
-                                     (< pos (point)))
-                            (throw 'done t))))
-                    (scan-error (throw 'done nil)))))))
-           ;; Non-keyword - skip
-           (t
-            (condition-case nil
-                (forward-sexp 1)
-              (scan-error (throw 'done nil))))))
-        nil))))
+Walk backward from POS through list structure looking for an
+enclosing `duckdb-query' call.  Handle the case where POS is
+inside a string by first moving to string start.
 
-(defun duckdb-query-font-lock--in-val-param-p (pos form-bounds)
-  "Return non-nil if POS is inside a :val parameter value in FORM-BOUNDS.
+Return form start position, or nil if POS is not inside a
+`duckdb-query' form.
 
-FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
-
-Called by `duckdb-query-font-lock--context-at-pos'."
-  (save-excursion
-    (let ((form-start (car form-bounds))
-          (form-end (cdr form-bounds)))
-      (goto-char form-start)
-      (forward-char 1)
-      (skip-chars-forward " \t\n")
-      ;; Skip function name
-      (forward-sexp 1)
-      ;; Parse keyword arguments
-      (catch 'done
-        (while (< (point) form-end)
-          (skip-chars-forward " \t\n")
-          (when (>= (point) form-end)
-            (throw 'done nil))
-          (cond
-           ;; Keyword argument
-           ((eq (char-after) ?:)
-            (let ((kw-start (point)))
-              (forward-sexp 1)
-              (let ((keyword (buffer-substring-no-properties kw-start (point))))
-                (skip-chars-forward " \t\n")
-                (let ((val-start (point)))
-                  (condition-case nil
-                      (progn
-                        (forward-sexp 1)
-                        (when (string= keyword ":val")
-                          (when (and (>= pos val-start)
-                                     (< pos (point)))
-                            (throw 'done t))))
-                    (scan-error (throw 'done nil)))))))
-           ;; Non-keyword - skip
-           (t
-            (condition-case nil
-                (forward-sexp 1)
-              (scan-error (throw 'done nil))))))
-        nil))))
-
-(defun duckdb-query-font-lock--context-at-pos (pos form-bounds)
-  "Determine the context of POS within `duckdb-query' FORM-BOUNDS.
-
-Return one of:
-  :query       Inside the query string argument
-  :sql-binding Inside a string in :sql parameter
-  :sql-wrapper Inside a string in (sql ...) wrapper in :val
-  nil          Not in a recognized string context
-
-FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
-
-Called by `duckdb-query-font-lock--get-context'."
+Called by `duckdb-query-font-lock--propertize'.
+Called by `duckdb-query-font-lock--extend-region'."
   (save-excursion
     (goto-char pos)
     (let ((ppss (syntax-ppss)))
-      ;; Must be inside a string
-      (unless (nth 3 ppss)
-        (throw 'context-result nil))
-      (let ((string-start (nth 8 ppss)))
-        ;; Check for (sql ...) wrapper first - most specific
-        (when (duckdb-query-font-lock--inside-sql-wrapper-p string-start)
-          (throw 'context-result :sql-wrapper))
-        ;; Check if in :sql parameter
-        (when (duckdb-query-font-lock--in-sql-param-p string-start form-bounds)
-          (throw 'context-result :sql-binding))
-        ;; Check if in :val parameter (but not in sql wrapper)
-        (when (duckdb-query-font-lock--in-val-param-p string-start form-bounds)
-          ;; In :val but not in (sql ...) - alist values, not SQL strings
-          (throw 'context-result nil))
-        ;; Otherwise, assume query string or similar valid context
-        :query))))
+      (when (nth 3 ppss)
+        (goto-char (nth 8 ppss))))
+    (let ((found nil))
+      (while (and (not found)
+                  (condition-case nil
+                      (progn (backward-up-list 1) t)
+                    (scan-error nil)))
+        (when (looking-at "(duckdb-query\\_>")
+          (setq found (point))))
+      found)))
 
-(defun duckdb-query-font-lock--get-context (pos form-bounds)
-  "Get context for POS within FORM-BOUNDS.
+;;;;; Region-Aware Fontification
 
-Wrapper for `duckdb-query-font-lock--context-at-pos' that handles
-the throw/catch control flow.
+(defun duckdb-query-font-lock--propertize (end)
+  "Fontify `duckdb-query' references between point and END.
 
-FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
+Search for `duckdb-query' forms in the region, parse each form,
+validate references, and apply faces.
 
-Called by `duckdb-query-font-lock--fontify-references'."
-  (catch 'context-result
-    (duckdb-query-font-lock--context-at-pos pos form-bounds)))
+When the region starts inside an existing form, find and fontify
+that form first before searching forward.
 
-(defun duckdb-query-font-lock--reference-valid-p (ref-type context)
-  "Return non-nil if REF-TYPE is valid in CONTEXT.
+Return nil to tell font-lock we applied faces ourselves.
 
-REF-TYPE is a string: \"sql\", \"data\", \"val\", or \"org\".
-CONTEXT is one of :query, :sql-binding, :sql-wrapper.
+Uses `duckdb-query--parse-at-point' for structural parsing.
+Uses `duckdb-query-font-lock--fontify-form' for face application."
+  (let ((start (point))
+        (fontified-forms (make-hash-table :test 'eq)))
+    ;; Handle region starting inside a duckdb-query form
+    (when-let ((form-start (duckdb-query-font-lock--find-form-start start)))
+      (unless (gethash form-start fontified-forms)
+        (save-excursion
+          (goto-char form-start)
+          (when-let ((parse-result (duckdb-query--parse-at-point)))
+            (duckdb-query-font-lock--fontify-form parse-result)
+            (puthash form-start t fontified-forms)
+            (setq start (max start
+                             (duckdb-query-parse-result-form-end
+                              parse-result)))))))
+    ;; Search forward for additional forms
+    (goto-char start)
+    (while (re-search-forward "(duckdb-query\\_>" end t)
+      (let ((form-start (match-beginning 0)))
+        (goto-char form-start)
+        (unless (or (duckdb-query--in-string-or-comment-p)
+                    (gethash form-start fontified-forms))
+          (when-let ((parse-result (duckdb-query--parse-at-point)))
+            (duckdb-query-font-lock--fontify-form parse-result)
+            (puthash form-start t fontified-forms)
+            (goto-char (duckdb-query-parse-result-form-end parse-result))))
+        (when (<= (point) form-start)
+          (goto-char (1+ form-start))))))
+  nil)
 
-Validity rules:
-- :query and :sql-binding allow all reference types
-- :sql-wrapper only allows @data: and @val: (not @sql: or @org:)
-
-The restriction on :sql-wrapper exists because @sql: substitution
-occurs before @val: processing.  References to @sql: inside (sql ...)
-expressions would remain as literal text.
-
-Called by `duckdb-query-font-lock--fontify-references'."
-  (pcase context
-    ((or :query :sql-binding)
-     t)
-    (:sql-wrapper
-     (member ref-type '("data" "val")))
-    (_
-     nil)))
-
-;;;; Font-lock Implementation
-
-(defun duckdb-query-font-lock--fontify-references (limit)
-  "Fontify @type:name references up to LIMIT.
-
-Search for references matching `duckdb-query-font-lock--reference-regexp'.
-For each match inside a `duckdb-query' form, apply appropriate faces:
-- Valid references: `duckdb-query-reference-prefix-face' and
-  `duckdb-query-reference-name-face'
-- Invalid references: `duckdb-query-reference-invalid-face'
-
-Return non-nil if any references were fontified.
-
-Installed by `duckdb-query-font-lock-mode' via `font-lock-add-keywords'."
-  (let ((found nil))
-    (while (re-search-forward duckdb-query-font-lock--reference-regexp limit t)
-      (let* ((prefix-beg (match-beginning 1))
-             (prefix-end (match-end 1))
-             (name-beg (match-beginning 2))
-             (name-end (match-end 2))
-             (ref-type (buffer-substring-no-properties
-                        (1+ prefix-beg)
-                        (1- prefix-end)))
-             (form-bounds (save-excursion
-                            (goto-char prefix-beg)
-                            (duckdb-query-font-lock--find-duckdb-query-form))))
-        (when form-bounds
-          (let ((context (duckdb-query-font-lock--get-context
-                          prefix-beg form-bounds)))
-            (when context
-              (setq found t)
-              (if (duckdb-query-font-lock--reference-valid-p ref-type context)
-                  ;; Valid reference - normal highlighting
-                  (progn
-                    (add-face-text-property prefix-beg prefix-end
-                                            'duckdb-query-reference-prefix-face)
-                    (add-face-text-property name-beg name-end
-                                            'duckdb-query-reference-name-face))
-                ;; Invalid reference - warning highlighting
-                (add-face-text-property prefix-beg name-end
-                                        'duckdb-query-reference-invalid-face)))))))
-    found))
-
-(defconst duckdb-query-font-lock-keywords
-  '((duckdb-query-font-lock--fontify-references))
+(defconst duckdb-query-font-lock--keywords
+  '(duckdb-query-font-lock--propertize)
   "Font-lock keywords for `duckdb-query' references.
 
 Installed by `duckdb-query-font-lock-mode'.")
+
+;;;;; Region Extension
+
+(defun duckdb-query-font-lock--extend-region ()
+  "Extend font-lock region to include complete `duckdb-query' forms.
+
+When `font-lock-beg' or `font-lock-end' falls inside a form,
+extend the region to include the entire form.  This ensures
+references are fontified correctly when JIT lock requests
+fontification of partial regions.
+
+Return non-nil if region was extended.
+
+Uses `duckdb-query-font-lock--find-form-start' for form detection.
+Installed on `font-lock-extend-region-functions' by
+`duckdb-query-font-lock-mode'."
+  (let ((extended nil))
+    (when-let ((form-start (duckdb-query-font-lock--find-form-start
+                            font-lock-beg)))
+      (when (< form-start font-lock-beg)
+        (setq font-lock-beg form-start
+              extended t)))
+    (when-let ((form-start (duckdb-query-font-lock--find-form-start
+                            font-lock-end)))
+      (save-excursion
+        (goto-char form-start)
+        (when-let ((parse-result (duckdb-query--parse-at-point)))
+          (let ((form-end (duckdb-query-parse-result-form-end parse-result)))
+            (when (> form-end font-lock-end)
+              (setq font-lock-end form-end
+                    extended t))))))
+    extended))
 
 ;;;; Minor Mode
 
@@ -568,13 +463,10 @@ When enabled, references like @org:table, @data:name, @val:value,
 and @sql:fragment are highlighted within SQL string arguments to
 `duckdb-query' and related functions.
 
-References are highlighted in:
-- The query string (first argument)
-- Strings inside :sql parameter bindings
-- Strings inside (sql ...) wrappers in :val bindings
-
-References in invalid positions (e.g., @sql: inside a (sql ...)
-wrapper) are highlighted with `duckdb-query-reference-invalid-face'.
+References are highlighted based on structural parsing by
+`duckdb-query-parse.el'.  Invalid references (undefined bindings
+or invalid context like @sql: in (sql ...) wrappers) are
+highlighted with `duckdb-query-reference-invalid-face'.
 
 To enable globally:
 
@@ -589,8 +481,13 @@ Also see `duckdb-query' for reference syntax documentation."
   (if duckdb-query-font-lock-mode
       (progn
         (duckdb-query-font-lock-apply-preset duckdb-query-font-lock-preset)
-        (font-lock-add-keywords nil duckdb-query-font-lock-keywords 'append))
-    (font-lock-remove-keywords nil duckdb-query-font-lock-keywords))
+        (font-lock-add-keywords nil duckdb-query-font-lock--keywords 'append)
+        (setq-local jit-lock-contextually t)
+        (add-hook 'font-lock-extend-region-functions
+                  #'duckdb-query-font-lock--extend-region nil t))
+    (font-lock-remove-keywords nil duckdb-query-font-lock--keywords)
+    (remove-hook 'font-lock-extend-region-functions
+                 #'duckdb-query-font-lock--extend-region t))
   (font-lock-flush))
 
 (provide 'duckdb-query-font-lock)

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -55,6 +55,9 @@
 (defvar font-lock-beg)
 (defvar font-lock-end)
 
+;; Defined by duckdb-query-parse.el, used by find-form function.
+(defvar duckdb-query--query-function-regexp)
+
 (defgroup duckdb-query-font-lock nil
   "Font-lock support for `duckdb-query' SQL strings."
   :group 'duckdb-query
@@ -347,14 +350,15 @@ Called by `duckdb-query-font-lock--propertize'."
 ;;;;; Form Detection
 
 (defun duckdb-query-font-lock--find-form-start (pos)
-  "Find start of `duckdb-query' form containing POS.
+  "Find start of `duckdb-query' family form containing POS.
 
 Walk backward from POS through list structure looking for an
-enclosing `duckdb-query' call.  Handle the case where POS is
-inside a string by first moving to string start.
+enclosing call matching `duckdb-query--query-function-regexp'.
+Handle the case where POS is inside a string by first moving
+to string start.
 
 Return form start position, or nil if POS is not inside a
-`duckdb-query' form.
+recognized form.
 
 Called by `duckdb-query-font-lock--propertize'.
 Called by `duckdb-query-font-lock--extend-region'."
@@ -368,7 +372,7 @@ Called by `duckdb-query-font-lock--extend-region'."
                   (condition-case nil
                       (progn (backward-up-list 1) t)
                     (scan-error nil)))
-        (when (looking-at "(duckdb-query\\_>")
+        (when (looking-at duckdb-query--query-function-regexp)
           (setq found (point))))
       found)))
 
@@ -377,8 +381,8 @@ Called by `duckdb-query-font-lock--extend-region'."
 (defun duckdb-query-font-lock--propertize (end)
   "Fontify `duckdb-query' references between point and END.
 
-Search for `duckdb-query' forms in the region, parse each form,
-validate references, and apply faces.
+Search for `duckdb-query' family forms in the region, parse each
+form, validate references, and apply faces.
 
 When the region starts inside an existing form, find and fontify
 that form first before searching forward.
@@ -389,7 +393,7 @@ Uses `duckdb-query--parse-at-point' for structural parsing.
 Uses `duckdb-query-font-lock--fontify-form' for face application."
   (let ((start (point))
         (fontified-forms (make-hash-table :test 'eq)))
-    ;; Handle region starting inside a duckdb-query form
+    ;; Handle region starting inside a form
     (when-let ((form-start (duckdb-query-font-lock--find-form-start start)))
       (unless (gethash form-start fontified-forms)
         (save-excursion
@@ -402,7 +406,7 @@ Uses `duckdb-query-font-lock--fontify-form' for face application."
                               parse-result)))))))
     ;; Search forward for additional forms
     (goto-char start)
-    (while (re-search-forward "(duckdb-query\\_>" end t)
+    (while (re-search-forward duckdb-query--query-function-regexp end t)
       (let ((form-start (match-beginning 0)))
         (goto-char form-start)
         (unless (or (duckdb-query--in-string-or-comment-p)

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -23,34 +23,34 @@
 
 ;;; Commentary:
 
-;; Provides font-lock highlighting for @type:name references within
-;; duckdb-query SQL strings.
+;; Highlight @type:name references in `duckdb-query' SQL strings.
 ;;
 ;; Basic usage:
 ;;
 ;;     (add-hook 'emacs-lisp-mode-hook #'duckdb-query-font-lock-mode)
 ;;
-;; For Org src blocks, the above hook is sufficient since Org's native
-;; fontification uses `emacs-lisp-mode' internally.  Optionally, also
-;; enable in Org buffers directly:
-;;
-;;     (add-hook 'org-mode-hook #'duckdb-query-font-lock-mode)
-;;
-;; Select a highlighting preset interactively:
+;; Select highlighting style interactively:
 ;;
 ;;     M-x duckdb-query-font-lock-select-preset
 ;;
 ;; Highlighted reference types:
-;; - @org:table-name - Org table references
-;; - @data:name - Elisp data bindings
-;; - @val:name - SQL variable literals
+;; - @org:name   Org table references
+;; - @data:name  Elisp data bindings
+;; - @val:name   SQL variable literals
+;; - @sql:name   SQL fragment substitution
+;;
+;; Invalid references (e.g., @sql: inside (sql ...) wrapper) use
+;; `duckdb-query-reference-invalid-face' to signal resolution failure.
+;;
+;; Also see `duckdb-query' for reference syntax documentation.
 
 ;;; Code:
 
 (require 'font-lock)
+(require 'cl-lib)
 
 (defgroup duckdb-query-font-lock nil
-  "Font-lock support for duckdb-query SQL strings."
+  "Font-lock support for `duckdb-query' SQL strings."
   :group 'duckdb-query
   :prefix "duckdb-query-font-lock-")
 
@@ -58,13 +58,39 @@
 
 (defface duckdb-query-reference-prefix-face
   '((t :inherit shadow))
-  "Face for @type: prefix in duckdb-query references."
-  :group 'duckdb-query-font-lock)
+  "Face for @type: prefix in `duckdb-query' references.
+
+Applied by `duckdb-query-font-lock--fontify-references' to the
+prefix portion of valid references (e.g., \"@val:\" in \"@val:name\").
+
+Customized via `duckdb-query-font-lock-preset' or directly."
+  :group 'duckdb-query-font-lock
+  :package-version '(duckdb-query . "0.7.0"))
 
 (defface duckdb-query-reference-name-face
   '((t :inherit font-lock-constant-face :weight bold))
-  "Face for the name portion of @type:name references."
-  :group 'duckdb-query-font-lock)
+  "Face for the name portion of @type:name references.
+
+Applied by `duckdb-query-font-lock--fontify-references' to the
+name portion of valid references (e.g., \"name\" in \"@val:name\").
+
+Customized via `duckdb-query-font-lock-preset' or directly."
+  :group 'duckdb-query-font-lock
+  :package-version '(duckdb-query . "0.7.0"))
+
+(defface duckdb-query-reference-invalid-face
+  '((t :inherit warning :weight bold))
+  "Face for references in semantically invalid positions.
+
+Applied to @sql: and @org: references inside (sql ...) wrappers,
+where substitution order prevents their resolution.  The @sql:
+substitution occurs before @val: processing, so @sql: references
+in (sql ...) expressions remain as literal text and cause parser
+errors.
+
+Also see `duckdb-query--substitute-sql-refs' for substitution order."
+  :group 'duckdb-query-font-lock
+  :package-version '(duckdb-query . "0.7.0"))
 
 ;;;; Presets
 
@@ -104,31 +130,49 @@
     (italic-shadow-bold-underline
      :prefix (:inherit shadow :slant italic)
      :name (:inherit font-lock-constant-face :weight bold :underline t)))
-  "Alist of highlighting presets for duckdb-query references.
-Each entry is (NAME :prefix PLIST :name PLIST).")
+  "Alist of highlighting presets for `duckdb-query' references.
+
+Each entry is (NAME :prefix FACE-ATTRS :name FACE-ATTRS) where
+FACE-ATTRS is a plist of face attributes.
+
+Applied by `duckdb-query-font-lock-apply-preset'.
+Selected via `duckdb-query-font-lock-select-preset'.")
 
 (defcustom duckdb-query-font-lock-preset 'shadow-bold-constant
-  "Current highlighting preset for duckdb-query references.
-Use `duckdb-query-font-lock-select-preset' to change interactively."
+  "Current highlighting preset for `duckdb-query' references.
+
+Controls appearance of `duckdb-query-reference-prefix-face' and
+`duckdb-query-reference-name-face'.
+
+Use `duckdb-query-font-lock-select-preset' to change interactively
+with live preview."
   :type `(choice ,@(mapcar (lambda (p) `(const ,(car p)))
                            duckdb-query-font-lock-presets))
   :group 'duckdb-query-font-lock
   :set (lambda (sym val)
          (set-default sym val)
          (when (fboundp 'duckdb-query-font-lock-apply-preset)
-           (duckdb-query-font-lock-apply-preset val))))
+           (duckdb-query-font-lock-apply-preset val)))
+  :package-version '(duckdb-query . "0.7.0"))
 
 ;;;; Preset Application
 
 (defun duckdb-query-font-lock-apply-preset (preset)
-  "Apply PRESET to duckdb-query reference faces.
-PRESET is a symbol naming an entry in `duckdb-query-font-lock-presets'."
+  "Apply PRESET to `duckdb-query' reference faces.
+
+PRESET is a symbol naming an entry in `duckdb-query-font-lock-presets'.
+
+Resets face attributes before applying new values.  Triggers
+`font-lock-flush' in all buffers with `duckdb-query-font-lock-mode'.
+
+Called by `duckdb-query-font-lock-select-preset' and the :set
+function of `duckdb-query-font-lock-preset'."
   (let ((entry (assq preset duckdb-query-font-lock-presets)))
     (unless entry
       (error "Unknown preset: %s" preset))
     (let ((prefix-attrs (plist-get (cdr entry) :prefix))
           (name-attrs (plist-get (cdr entry) :name)))
-      ;; Reset faces
+      ;; Reset faces to default state
       (set-face-attribute 'duckdb-query-reference-prefix-face nil
                           :inherit nil :weight 'normal :slant 'normal
                           :underline nil :foreground 'unspecified
@@ -154,13 +198,24 @@ PRESET is a symbol naming an entry in `duckdb-query-font-lock-presets'."
   "Minibuffer history for `duckdb-query-font-lock-select-preset'.")
 
 (defvar duckdb-query-font-lock--saved-preset nil
-  "Saved preset for restoration on cancel.")
+  "Saved preset for restoration on cancel.
+
+Bound by `duckdb-query-font-lock-select-preset' before entering
+minibuffer.  Restored if user cancels with \\[keyboard-quit].")
 
 (defvar duckdb-query-font-lock--last-previewed nil
-  "Last previewed preset to avoid redundant applications.")
+  "Last previewed preset to avoid redundant applications.
+
+Compared against current candidate in `duckdb-query-font-lock--preview-preset'
+to prevent re-applying the same preset on every keystroke.")
 
 (defun duckdb-query-font-lock--preview-preset ()
-  "Preview the currently selected preset in minibuffer."
+  "Preview the currently selected preset in minibuffer.
+
+Extracts current candidate from vertico, icomplete, or standard
+completion and applies it via `duckdb-query-font-lock-apply-preset'.
+
+Called by `post-command-hook' in minibuffer during preset selection."
   (when (minibufferp)
     (when-let* ((candidate (or
                             ;; Vertico
@@ -183,18 +238,26 @@ PRESET is a symbol naming an entry in `duckdb-query-font-lock-presets'."
       (duckdb-query-font-lock-apply-preset preset))))
 
 (defun duckdb-query-font-lock--setup-preview ()
-  "Setup preview hooks in minibuffer."
+  "Setup preview hooks in minibuffer.
+
+Installs `duckdb-query-font-lock--preview-preset' on `post-command-hook'
+for live preview during `duckdb-query-font-lock-select-preset'."
   (setq duckdb-query-font-lock--last-previewed nil)
   (add-hook 'post-command-hook #'duckdb-query-font-lock--preview-preset nil t))
 
 ;;;###autoload
 (defun duckdb-query-font-lock-select-preset (preset)
   "Select a highlighting PRESET with live preview.
+
 Interactively, show completion with preview as you navigate
-candidates.  Works with `vertico', `icomplete', `fido-mode', and
+candidates.  Works with vertico, icomplete, fido-mode, and
 standard completion.
 
-PRESET is a symbol from `duckdb-query-font-lock-presets'."
+PRESET is a symbol from `duckdb-query-font-lock-presets'.
+
+On \\[keyboard-quit], restore the previous preset.
+
+Also see `duckdb-query-font-lock-preset' for programmatic access."
   (interactive
    (let ((duckdb-query-font-lock--saved-preset duckdb-query-font-lock-preset)
          (selected nil))
@@ -219,98 +282,308 @@ PRESET is a symbol from `duckdb-query-font-lock-presets'."
     (duckdb-query-font-lock-apply-preset preset)
     (message "Applied preset: %s" preset)))
 
-;;;; Font-lock Implementation
+;;;; Context Detection
 
 (defconst duckdb-query-font-lock--query-functions
-  '(duckdb-query)
-  "`duckdb-query' Functions whose first string argument is a SQL query.")
+  '(duckdb-query duckdb-query-value duckdb-query-row duckdb-query-column)
+  "Functions whose first string argument is a SQL query.
+
+Used by `duckdb-query-font-lock--find-duckdb-query-form' to identify
+forms containing highlightable references.")
 
 (defconst duckdb-query-font-lock--reference-regexp
   (rx (group "@" (or "org" "data" "val" "sql") ":")
       (group (any "a-zA-Z_") (* (any "a-zA-Z0-9_:/-"))))
   "Regexp matching @type:name references.
+
 Group 1: @type: prefix.
 Group 2: name.
 
-Reference types:
-- org:  Org table references via `org-babel-ref-resolve'
-- data: Elisp data bindings from :data parameter
-- val:  SQL variable literals from :val parameter
-- sql:  SQL string fragments for query construction")
+Used by `duckdb-query-font-lock--fontify-references'.")
 
-(defun duckdb-query-font-lock--in-quoted-context-p ()
-  "Return non-nil if point is inside a quoted form."
+(defun duckdb-query-font-lock--find-duckdb-query-form ()
+  "Find the containing `duckdb-query' form if point is inside one.
+
+Return (FORM-START . FORM-END) if found, nil otherwise.
+
+Traverses upward through sexp structure, checking each containing
+list for a `duckdb-query' family function at its head.  Handles
+quoted data structures correctly.
+
+Called by `duckdb-query-font-lock--fontify-references'."
   (save-excursion
-    (catch 'quoted
-      (while (let ((paren-pos (nth 1 (syntax-ppss))))
-               (when paren-pos
-                 (goto-char paren-pos)
-                 (when (memq (char-before) '(?\' ?\`))
-                   (throw 'quoted t))
-                 (when (looking-at "([ \t\n]*quote\\_>")
-                   (throw 'quoted t))
-                 t)))
-      nil)))
+    (let ((depth 0))
+      (catch 'found
+        (while (< depth 50)  ; Safety limit
+          (let ((paren-pos (nth 1 (syntax-ppss))))
+            (unless paren-pos
+              (throw 'found nil))
+            (goto-char paren-pos)
+            (cl-incf depth)
+            ;; Check if this paren starts a duckdb-query call
+            (save-excursion
+              (forward-char 1)
+              (skip-chars-forward " \t\n")
+              (when (looking-at "\\_<\\(duckdb-query[-a-z]*\\)\\_>")
+                (let ((func-name (intern (match-string 1))))
+                  (when (memq func-name duckdb-query-font-lock--query-functions)
+                    ;; Verify not quoted at top level
+                    (goto-char paren-pos)
+                    (let ((outer-paren (nth 1 (syntax-ppss))))
+                      (when (or outer-paren
+                                (not (memq (char-before paren-pos) '(?\' ?\`))))
+                        (goto-char paren-pos)
+                        (forward-sexp 1)
+                        (throw 'found (cons paren-pos (point)))))))))))))))
 
-(defun duckdb-query-font-lock--in-duckdb-query-string-p (pos)
-  "Return non-nil if POS is inside a duckdb-query SQL string."
+(defun duckdb-query-font-lock--inside-sql-wrapper-p (pos)
+  "Return non-nil if POS is inside a (sql ...) wrapper.
+
+Checks parent sexps for a list starting with symbol `sql'.
+
+Called by `duckdb-query-font-lock--context-at-pos'."
+  (save-excursion
+    (goto-char pos)
+    (let ((depth 0))
+      (catch 'found
+        (while (< depth 20)  ; Safety limit
+          (let ((paren-pos (nth 1 (syntax-ppss))))
+            (unless paren-pos
+              (throw 'found nil))
+            (goto-char paren-pos)
+            (when (looking-at "([ \t\n]*sql\\_>")
+              (throw 'found t))
+            (cl-incf depth)))
+        nil))))
+
+(defun duckdb-query-font-lock--in-sql-param-p (pos form-bounds)
+  "Return non-nil if POS is inside a :sql parameter value in FORM-BOUNDS.
+
+FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
+
+Called by `duckdb-query-font-lock--context-at-pos'."
+  (save-excursion
+    (let ((form-start (car form-bounds))
+          (form-end (cdr form-bounds)))
+      (goto-char form-start)
+      (forward-char 1)
+      (skip-chars-forward " \t\n")
+      ;; Skip function name
+      (forward-sexp 1)
+      ;; Parse keyword arguments
+      (catch 'done
+        (while (< (point) form-end)
+          (skip-chars-forward " \t\n")
+          (when (>= (point) form-end)
+            (throw 'done nil))
+          (cond
+           ;; Keyword argument
+           ((eq (char-after) ?:)
+            (let ((kw-start (point)))
+              (forward-sexp 1)
+              (let ((keyword (buffer-substring-no-properties kw-start (point))))
+                (skip-chars-forward " \t\n")
+                (let ((val-start (point)))
+                  (condition-case nil
+                      (progn
+                        (forward-sexp 1)
+                        (when (string= keyword ":sql")
+                          (when (and (>= pos val-start)
+                                     (< pos (point)))
+                            (throw 'done t))))
+                    (scan-error (throw 'done nil)))))))
+           ;; Non-keyword - skip
+           (t
+            (condition-case nil
+                (forward-sexp 1)
+              (scan-error (throw 'done nil))))))
+        nil))))
+
+(defun duckdb-query-font-lock--in-val-param-p (pos form-bounds)
+  "Return non-nil if POS is inside a :val parameter value in FORM-BOUNDS.
+
+FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
+
+Called by `duckdb-query-font-lock--context-at-pos'."
+  (save-excursion
+    (let ((form-start (car form-bounds))
+          (form-end (cdr form-bounds)))
+      (goto-char form-start)
+      (forward-char 1)
+      (skip-chars-forward " \t\n")
+      ;; Skip function name
+      (forward-sexp 1)
+      ;; Parse keyword arguments
+      (catch 'done
+        (while (< (point) form-end)
+          (skip-chars-forward " \t\n")
+          (when (>= (point) form-end)
+            (throw 'done nil))
+          (cond
+           ;; Keyword argument
+           ((eq (char-after) ?:)
+            (let ((kw-start (point)))
+              (forward-sexp 1)
+              (let ((keyword (buffer-substring-no-properties kw-start (point))))
+                (skip-chars-forward " \t\n")
+                (let ((val-start (point)))
+                  (condition-case nil
+                      (progn
+                        (forward-sexp 1)
+                        (when (string= keyword ":val")
+                          (when (and (>= pos val-start)
+                                     (< pos (point)))
+                            (throw 'done t))))
+                    (scan-error (throw 'done nil)))))))
+           ;; Non-keyword - skip
+           (t
+            (condition-case nil
+                (forward-sexp 1)
+              (scan-error (throw 'done nil))))))
+        nil))))
+
+(defun duckdb-query-font-lock--context-at-pos (pos form-bounds)
+  "Determine the context of POS within `duckdb-query' FORM-BOUNDS.
+
+Return one of:
+  :query       Inside the query string argument
+  :sql-binding Inside a string in :sql parameter
+  :sql-wrapper Inside a string in (sql ...) wrapper in :val
+  nil          Not in a recognized string context
+
+FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
+
+Called by `duckdb-query-font-lock--get-context'."
   (save-excursion
     (goto-char pos)
     (let ((ppss (syntax-ppss)))
-      (when (and (nth 3 ppss)
-                 (not (nth 4 ppss)))
-        (let ((string-start (nth 8 ppss)))
-          (goto-char string-start)
-          (unless (duckdb-query-font-lock--in-quoted-context-p)
-            (let ((paren-pos (nth 1 (syntax-ppss))))
-              (when paren-pos
-                (goto-char paren-pos)
-                (forward-char 1)
-                (skip-chars-forward " \t\n")
-                (and (looking-at "\\_<\\(duckdb-query[-a-z]*\\)\\_>")
-                     (memq (intern (match-string 1))
-                           duckdb-query-font-lock--query-functions)
-                     (progn
-                       (goto-char (match-end 0))
-                       (skip-chars-forward " \t\n")
-                       (= (point) string-start)))))))))))
+      ;; Must be inside a string
+      (unless (nth 3 ppss)
+        (throw 'context-result nil))
+      (let ((string-start (nth 8 ppss)))
+        ;; Check for (sql ...) wrapper first - most specific
+        (when (duckdb-query-font-lock--inside-sql-wrapper-p string-start)
+          (throw 'context-result :sql-wrapper))
+        ;; Check if in :sql parameter
+        (when (duckdb-query-font-lock--in-sql-param-p string-start form-bounds)
+          (throw 'context-result :sql-binding))
+        ;; Check if in :val parameter (but not in sql wrapper)
+        (when (duckdb-query-font-lock--in-val-param-p string-start form-bounds)
+          ;; In :val but not in (sql ...) - alist values, not SQL strings
+          (throw 'context-result nil))
+        ;; Otherwise, assume query string or similar valid context
+        :query))))
+
+(defun duckdb-query-font-lock--get-context (pos form-bounds)
+  "Get context for POS within FORM-BOUNDS.
+
+Wrapper for `duckdb-query-font-lock--context-at-pos' that handles
+the throw/catch control flow.
+
+FORM-BOUNDS is (START . END) of the containing `duckdb-query' form.
+
+Called by `duckdb-query-font-lock--fontify-references'."
+  (catch 'context-result
+    (duckdb-query-font-lock--context-at-pos pos form-bounds)))
+
+(defun duckdb-query-font-lock--reference-valid-p (ref-type context)
+  "Return non-nil if REF-TYPE is valid in CONTEXT.
+
+REF-TYPE is a string: \"sql\", \"data\", \"val\", or \"org\".
+CONTEXT is one of :query, :sql-binding, :sql-wrapper.
+
+Validity rules:
+- :query and :sql-binding allow all reference types
+- :sql-wrapper only allows @data: and @val: (not @sql: or @org:)
+
+The restriction on :sql-wrapper exists because @sql: substitution
+occurs before @val: processing.  References to @sql: inside (sql ...)
+expressions would remain as literal text.
+
+Called by `duckdb-query-font-lock--fontify-references'."
+  (pcase context
+    ((or :query :sql-binding)
+     t)
+    (:sql-wrapper
+     (member ref-type '("data" "val")))
+    (_
+     nil)))
+
+;;;; Font-lock Implementation
 
 (defun duckdb-query-font-lock--fontify-references (limit)
-  "Fontify @type:name references up to LIMIT."
+  "Fontify @type:name references up to LIMIT.
+
+Search for references matching `duckdb-query-font-lock--reference-regexp'.
+For each match inside a `duckdb-query' form, apply appropriate faces:
+- Valid references: `duckdb-query-reference-prefix-face' and
+  `duckdb-query-reference-name-face'
+- Invalid references: `duckdb-query-reference-invalid-face'
+
+Return non-nil if any references were fontified.
+
+Installed by `duckdb-query-font-lock-mode' via `font-lock-add-keywords'."
   (let ((found nil))
     (while (re-search-forward duckdb-query-font-lock--reference-regexp limit t)
-      (let ((prefix-beg (match-beginning 1))
-            (prefix-end (match-end 1))
-            (name-beg (match-beginning 2))
-            (name-end (match-end 2)))
-        (when (duckdb-query-font-lock--in-duckdb-query-string-p prefix-beg)
-          (setq found t)
-          (add-face-text-property prefix-beg prefix-end
-                                  'duckdb-query-reference-prefix-face)
-          (add-face-text-property name-beg name-end
-                                  'duckdb-query-reference-name-face))))
+      (let* ((prefix-beg (match-beginning 1))
+             (prefix-end (match-end 1))
+             (name-beg (match-beginning 2))
+             (name-end (match-end 2))
+             (ref-type (buffer-substring-no-properties
+                        (1+ prefix-beg)
+                        (1- prefix-end)))
+             (form-bounds (save-excursion
+                            (goto-char prefix-beg)
+                            (duckdb-query-font-lock--find-duckdb-query-form))))
+        (when form-bounds
+          (let ((context (duckdb-query-font-lock--get-context
+                          prefix-beg form-bounds)))
+            (when context
+              (setq found t)
+              (if (duckdb-query-font-lock--reference-valid-p ref-type context)
+                  ;; Valid reference - normal highlighting
+                  (progn
+                    (add-face-text-property prefix-beg prefix-end
+                                            'duckdb-query-reference-prefix-face)
+                    (add-face-text-property name-beg name-end
+                                            'duckdb-query-reference-name-face))
+                ;; Invalid reference - warning highlighting
+                (add-face-text-property prefix-beg name-end
+                                        'duckdb-query-reference-invalid-face)))))))
     found))
 
 (defconst duckdb-query-font-lock-keywords
   '((duckdb-query-font-lock--fontify-references))
-  "Font-lock keywords for duckdb-query references.")
+  "Font-lock keywords for `duckdb-query' references.
+
+Installed by `duckdb-query-font-lock-mode'.")
 
 ;;;; Minor Mode
 
 ;;;###autoload
 (define-minor-mode duckdb-query-font-lock-mode
-  "Minor mode for highlighting @type:name references in duckdb-query strings.
+  "Highlight @type:name references in `duckdb-query' forms.
 
 When enabled, references like @org:table, @data:name, @val:value,
-and @expr:query are highlighted within SQL string arguments to
+and @sql:fragment are highlighted within SQL string arguments to
 `duckdb-query' and related functions.
+
+References are highlighted in:
+- The query string (first argument)
+- Strings inside :sql parameter bindings
+- Strings inside (sql ...) wrappers in :val bindings
+
+References in invalid positions (e.g., @sql: inside a (sql ...)
+wrapper) are highlighted with `duckdb-query-reference-invalid-face'.
 
 To enable globally:
 
     (add-hook \\='emacs-lisp-mode-hook #\\='duckdb-query-font-lock-mode)
 
 Use `duckdb-query-font-lock-select-preset' to change highlighting
-style interactively with live preview."
+style interactively with live preview.
+
+Also see `duckdb-query' for reference syntax documentation."
   :lighter " DQ"
   :group 'duckdb-query-font-lock
   (if duckdb-query-font-lock-mode

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -162,6 +162,48 @@ with live preview."
            (duckdb-query-font-lock-apply-preset val)))
   :package-version '(duckdb-query . "0.7.0"))
 
+(defcustom duckdb-query-font-lock-in-org-src-blocks t
+  "Whether to highlight references in `org-mode' src block fontification.
+
+When non-nil, `duckdb-query-font-lock-mode' installs font-lock
+keywords in org's internal fontification buffers with minimal
+overhead, skipping preset application, region extension hooks,
+and contextual JIT lock setup.
+
+When nil, font-lock keywords are not installed in org fontification
+buffers.  References still highlight in dedicated src edit buffers
+opened via \\[org-edit-special].
+
+Has no effect unless `duckdb-query-font-lock-mode' is on
+`emacs-lisp-mode-hook'.
+
+Also see `duckdb-query-font-lock-mode'."
+  :type 'boolean
+  :group 'duckdb-query-font-lock
+  :package-version '(duckdb-query . "0.8.0"))
+
+(defcustom duckdb-query-font-lock-max-buffer-size nil
+  "Maximum buffer size in bytes for reference fontification.
+
+When non-nil and buffer size exceeds this value, fontification
+behavior depends on context:
+
+In `emacs-lisp-mode' buffers, `duckdb-query-font-lock--propertize'
+skips propertization entirely.
+
+In org src fontification buffers, the mode inhibits activation
+regardless of `duckdb-query-font-lock-in-org-src-blocks'.  The
+buffer size checked is the org buffer's size, not the fontification
+buffer's size.
+
+When nil, fontify regardless of buffer size.
+
+Also see `duckdb-query-complete-max-buffer-size'."
+  :type '(choice (const :tag "No limit" nil)
+                 (integer :tag "Maximum bytes"))
+  :group 'duckdb-query-font-lock
+  :package-version '(duckdb-query . "0.8.0"))
+
 ;;;; Preset Application
 
 (defun duckdb-query-font-lock-apply-preset (preset)
@@ -387,36 +429,43 @@ form, validate references, and apply faces.
 When the region starts inside an existing form, find and fontify
 that form first before searching forward.
 
+Skip fontification when buffer size exceeds
+`duckdb-query-font-lock-max-buffer-size'.  This guard protects
+standalone `emacs-lisp-mode' buffers; org fontification buffers
+are guarded at mode activation time.
+
 Return nil to tell font-lock we applied faces ourselves.
 
 Uses `duckdb-query--parse-at-point' for structural parsing.
 Uses `duckdb-query-font-lock--fontify-form' for face application."
-  (let ((start (point))
-        (fontified-forms (make-hash-table :test 'eq)))
-    ;; Handle region starting inside a form
-    (when-let ((form-start (duckdb-query-font-lock--find-form-start start)))
-      (unless (gethash form-start fontified-forms)
-        (save-excursion
+  (when (or (null duckdb-query-font-lock-max-buffer-size)
+            (<= (buffer-size) duckdb-query-font-lock-max-buffer-size))
+    (let ((start (point))
+          (fontified-forms (make-hash-table :test 'eq)))
+      ;; Handle region starting inside a form
+      (when-let ((form-start (duckdb-query-font-lock--find-form-start start)))
+        (unless (gethash form-start fontified-forms)
+          (save-excursion
+            (goto-char form-start)
+            (when-let ((parse-result (duckdb-query--parse-at-point)))
+              (duckdb-query-font-lock--fontify-form parse-result)
+              (puthash form-start t fontified-forms)
+              (setq start (max start
+                               (duckdb-query-parse-result-form-end
+                                parse-result)))))))
+      ;; Search forward for additional forms
+      (goto-char start)
+      (while (re-search-forward duckdb-query--query-function-regexp end t)
+        (let ((form-start (match-beginning 0)))
           (goto-char form-start)
-          (when-let ((parse-result (duckdb-query--parse-at-point)))
-            (duckdb-query-font-lock--fontify-form parse-result)
-            (puthash form-start t fontified-forms)
-            (setq start (max start
-                             (duckdb-query-parse-result-form-end
-                              parse-result)))))))
-    ;; Search forward for additional forms
-    (goto-char start)
-    (while (re-search-forward duckdb-query--query-function-regexp end t)
-      (let ((form-start (match-beginning 0)))
-        (goto-char form-start)
-        (unless (or (duckdb-query--in-string-or-comment-p)
-                    (gethash form-start fontified-forms))
-          (when-let ((parse-result (duckdb-query--parse-at-point)))
-            (duckdb-query-font-lock--fontify-form parse-result)
-            (puthash form-start t fontified-forms)
-            (goto-char (duckdb-query-parse-result-form-end parse-result))))
-        (when (<= (point) form-start)
-          (goto-char (1+ form-start))))))
+          (unless (or (duckdb-query--in-string-or-comment-p)
+                      (gethash form-start fontified-forms))
+            (when-let ((parse-result (duckdb-query--parse-at-point)))
+              (duckdb-query-font-lock--fontify-form parse-result)
+              (puthash form-start t fontified-forms)
+              (goto-char (duckdb-query-parse-result-form-end parse-result))))
+          (when (<= (point) form-start)
+            (goto-char (1+ form-start)))))))
   nil)
 
 (defconst duckdb-query-font-lock--keywords
@@ -457,6 +506,37 @@ Installed on `font-lock-extend-region-functions' by
                     extended t))))))
     extended))
 
+(defun duckdb-query-font-lock--in-org-fontification-p ()
+  "Return non-nil if current buffer is an org src fontification buffer.
+
+Org creates temporary buffers named \" org-src-fontification:*\"
+for src block font-lock.  These buffers run language major modes
+but benefit from lightweight mode activation that skips expensive
+setup like preset application and region extension hooks.
+
+Called by `duckdb-query-font-lock-mode' to select activation path."
+  (string-prefix-p " org-src-fontification:"
+                    (buffer-name)))
+
+(defun duckdb-query-font-lock--org-buffer-too-large-p ()
+  "Return non-nil if the org buffer being fontified exceeds size threshold.
+
+In org fontification buffers, `org-src--source-type' or the buffer
+from which fontification was requested may not be directly accessible.
+Use `buffer-local-value' on buffers matching the org file, or check
+all `org-mode' buffers.
+
+Falls back to checking if any `org-mode' buffer exceeds the threshold,
+which is conservative but safe."
+  (and duckdb-query-font-lock-max-buffer-size
+       (cl-some (lambda (buf)
+                  (and (buffer-live-p buf)
+                       (with-current-buffer buf
+                         (derived-mode-p 'org-mode))
+                       (> (buffer-size buf)
+                          duckdb-query-font-lock-max-buffer-size)))
+                (buffer-list))))
+
 ;;;; Minor Mode
 
 ;;;###autoload
@@ -472,6 +552,13 @@ References are highlighted based on structural parsing by
 or invalid context like @sql: in (sql ...) wrappers) are
 highlighted with `duckdb-query-reference-invalid-face'.
 
+In org src fontification buffers, activation is lightweight: only
+font-lock keywords are installed, skipping preset application and
+region extension hooks.  Controlled by
+`duckdb-query-font-lock-in-org-src-blocks'.  Inhibited entirely
+when `duckdb-query-font-lock-max-buffer-size' is set and the org
+buffer exceeds the threshold.
+
 To enable globally:
 
     (add-hook \\='emacs-lisp-mode-hook #\\='duckdb-query-font-lock-mode)
@@ -482,17 +569,34 @@ style interactively with live preview.
 Also see `duckdb-query' for reference syntax documentation."
   :lighter " DQ"
   :group 'duckdb-query-font-lock
-  (if duckdb-query-font-lock-mode
-      (progn
-        (duckdb-query-font-lock-apply-preset duckdb-query-font-lock-preset)
-        (font-lock-add-keywords nil duckdb-query-font-lock--keywords 'append)
-        (setq-local jit-lock-contextually t)
-        (add-hook 'font-lock-extend-region-functions
-                  #'duckdb-query-font-lock--extend-region nil t))
+  (cond
+   ;; Org fontification buffer
+   ((and duckdb-query-font-lock-mode
+         (duckdb-query-font-lock--in-org-fontification-p))
+    (cond
+     ;; Org buffer too large: inhibit
+     ((duckdb-query-font-lock--org-buffer-too-large-p)
+      (setq duckdb-query-font-lock-mode nil))
+     ;; Lightweight activation enabled
+     (duckdb-query-font-lock-in-org-src-blocks
+      (font-lock-add-keywords nil duckdb-query-font-lock--keywords 'append))
+     ;; Inhibit entirely
+     (t
+      (setq duckdb-query-font-lock-mode nil))))
+   ;; Normal enable
+   (duckdb-query-font-lock-mode
+    (duckdb-query-font-lock-apply-preset duckdb-query-font-lock-preset)
+    (font-lock-add-keywords nil duckdb-query-font-lock--keywords 'append)
+    (setq-local jit-lock-contextually t)
+    (add-hook 'font-lock-extend-region-functions
+              #'duckdb-query-font-lock--extend-region nil t)
+    (font-lock-flush))
+   ;; Disable
+   (t
     (font-lock-remove-keywords nil duckdb-query-font-lock--keywords)
     (remove-hook 'font-lock-extend-region-functions
-                 #'duckdb-query-font-lock--extend-region t))
-  (font-lock-flush))
+                 #'duckdb-query-font-lock--extend-region t)
+    (font-lock-flush))))
 
 (provide 'duckdb-query-font-lock)
 

--- a/duckdb-query-font-lock.el
+++ b/duckdb-query-font-lock.el
@@ -227,10 +227,18 @@ PRESET is a symbol from `duckdb-query-font-lock-presets'."
   "`duckdb-query' Functions whose first string argument is a SQL query.")
 
 (defconst duckdb-query-font-lock--reference-regexp
-  "\\(@\\(?:org\\|data\\|var\\|expr\\):\\)\\([a-zA-Z_][a-zA-Z0-9_:/-]*\\)"
+  (rx (group "@" (or "org" "data" "var" "expr" "sql") ":")
+      (group (any "a-zA-Z_") (* (any "a-zA-Z0-9_:/-"))))
   "Regexp matching @type:name references.
 Group 1: @type: prefix.
-Group 2: name.")
+Group 2: name.
+
+Reference types:
+- org:  Org table references via `org-babel-ref-resolve'
+- data: Elisp data bindings from :data parameter
+- var:  SQL variable literals from :var parameter
+- expr: SQL expressions from :var parameter
+- sql:  SQL string fragments for query construction")
 
 (defun duckdb-query-font-lock--in-quoted-context-p ()
   "Return non-nil if point is inside a quoted form."

--- a/duckdb-query-parse.el
+++ b/duckdb-query-parse.el
@@ -432,7 +432,9 @@ Return nil if reference is valid.
 Return error keyword if invalid:
   :invalid-sql-in-val - @sql: reference inside :val parameter
   :invalid-org-in-val - @org: reference inside :val parameter
-  :undefined          - reference name not found in bindings"
+  :undefined          - reference name not found in bindings
+
+Called by `duckdb-query--validate-all-references'."
   (let ((type (plist-get ref :type))
         (name (plist-get ref :name))
         (context (plist-get ref :context)))

--- a/duckdb-query-parse.el
+++ b/duckdb-query-parse.el
@@ -1,0 +1,478 @@
+;;; duckdb-query-parse.el --- Parser for duckdb-query forms -*- lexical-binding: t; -*-
+;;
+;; Author: Gino Cornejo <gggion123@gmail.com>
+;; Maintainer: Gino Cornejo <gggion123@gmail.com>
+;; Homepage: https://github.com/gggion/duckdb-query.el
+
+;; This file is part of duckdb-query.
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Structural parser for `duckdb-query' forms in Elisp buffers.
+;;
+;; Extracts form bounds, SQL strings, keyword parameters, binding
+;; definitions, and reference locations for use by fontification,
+;; linting, and completion systems.
+;;
+;; Basic usage:
+;;
+;;     (duckdb-query--parse-at-point)
+;;     ;; => #s(duckdb-query-parse-result ...)
+;;
+;;     (duckdb-query-parse-buffer)
+;;     ;; => list of parse results for all forms
+;;
+;; The parser handles comments, quoted and backquoted forms, and
+;; validates references against declared bindings.
+
+;;; Code:
+
+(require 'cl-lib)
+
+;;;; Character Constants
+
+(defconst duckdb-query--char-lparen ?\(
+  "Left parenthesis character.")
+
+(defconst duckdb-query--char-rparen ?\)
+  "Right parenthesis character.")
+
+(defconst duckdb-query--char-quote ?\'
+  "Quote character.")
+
+(defconst duckdb-query--char-backquote ?\`
+  "Backquote character.")
+
+(defconst duckdb-query--char-comma ?\,
+  "Comma (unquote) character.")
+
+(defconst duckdb-query--char-at ?\@
+  "At-sign character, used as splice marker after comma.")
+
+(defconst duckdb-query--char-dot ?\.
+  "Dot character, used as cons pair separator.")
+
+(defconst duckdb-query--char-colon ?\:
+  "Colon character, used as keyword prefix.")
+
+(defconst duckdb-query--char-double-quote ?\"
+  "Double-quote character, used as string delimiter.")
+
+(defconst duckdb-query--char-semicolon ?\;
+  "Semicolon character, used as comment prefix.")
+
+;;;; Core Position Utilities
+
+(defsubst duckdb-query--in-string-p ()
+  "Return start of string if point is inside one, nil otherwise.
+Uses `syntax-ppss' to determine parse state."
+  (nth 8 (syntax-ppss)))
+
+(defsubst duckdb-query--in-comment-p ()
+  "Return non-nil if point is inside a comment.
+Uses `syntax-ppss' to determine parse state."
+  (nth 4 (syntax-ppss)))
+
+(defsubst duckdb-query--in-string-or-comment-p ()
+  "Return start position if point is in string or comment, nil otherwise.
+For strings, returns string start position.
+For comments, returns current point."
+  (let ((state (syntax-ppss)))
+    (or (nth 8 state)
+        (and (nth 4 state) (point)))))
+
+(defun duckdb-query--skip-whitespace-and-comments ()
+  "Skip forward over whitespace and comments.
+Handles both inline comments and comment-only lines."
+  (while (or (looking-at-p "[ \t\n]")
+             (duckdb-query--in-comment-p)
+             (eq (char-after) duckdb-query--char-semicolon))
+    (if (or (duckdb-query--in-comment-p)
+            (eq (char-after) duckdb-query--char-semicolon))
+        (forward-line 1)
+      (skip-chars-forward " \t\n"))))
+
+(defun duckdb-query--forward-sexp-safe ()
+  "Move forward one sexp.
+Return end position on success, nil on scan error."
+  (condition-case nil
+      (progn (forward-sexp 1) (point))
+    (scan-error nil)))
+
+(defun duckdb-query--backward-up-list-safe ()
+  "Move backward up one list level.
+Return new position on success, nil on scan error."
+  (condition-case nil
+      (progn (backward-up-list 1) (point))
+    (scan-error nil)))
+
+;;;; Form Location
+
+(defun duckdb-query--find-enclosing-form ()
+  "Find enclosing `duckdb-query' form containing point.
+Return (BEG . END) cons cell with form bounds, or nil if point
+is not inside a `duckdb-query' form.
+
+Checks if point is directly on a `duckdb-query' form first,
+then walks up the list structure checking each enclosing list."
+  (save-excursion
+    (when-let ((str-start (duckdb-query--in-string-p)))
+      (goto-char str-start))
+    (catch 'found
+      ;; Check if directly on a duckdb-query form
+      (when (looking-at "(duckdb-query\\_>")
+        (let ((beg (point)))
+          (when (duckdb-query--forward-sexp-safe)
+            (throw 'found (cons beg (point))))))
+      ;; Walk up list structure
+      (while (duckdb-query--backward-up-list-safe)
+        (when (looking-at "(duckdb-query\\_>")
+          (let ((beg (point)))
+            (when (duckdb-query--forward-sexp-safe)
+              (throw 'found (cons beg (point)))))))
+      nil)))
+
+;;;; String Extraction
+
+(defun duckdb-query--string-bounds-at (pos)
+  "Return bounds of string at POS as (BEG . END), or nil.
+POS must be inside a string for bounds to be returned."
+  (save-excursion
+    (goto-char pos)
+    (let ((state (syntax-ppss)))
+      (when (nth 3 state)
+        (let ((beg (nth 8 state)))
+          (goto-char beg)
+          (when (duckdb-query--forward-sexp-safe)
+            (cons beg (point))))))))
+
+(defun duckdb-query--collect-strings-in-region (beg end)
+  "Collect all string literal bounds between BEG and END.
+Return list of (START . END) cons cells for each string.
+Skips strings inside comments."
+  (save-excursion
+    (goto-char beg)
+    (let (strings)
+      (while (and (< (point) end)
+                  (search-forward "\"" end t))
+        (let ((quote-pos (1- (point))))
+          (unless (duckdb-query--in-comment-p)
+            (goto-char quote-pos)
+            (let ((state (syntax-ppss)))
+              (if (nth 3 state)
+                  (let ((str-beg (nth 8 state)))
+                    (goto-char str-beg)
+                    (when (duckdb-query--forward-sexp-safe)
+                      (push (cons str-beg (point)) strings)))
+                (when (duckdb-query--forward-sexp-safe)
+                  (push (cons quote-pos (point)) strings)))))))
+      (nreverse strings))))
+
+;;;; Reference Pattern Matching
+
+(defconst duckdb-query--reference-regexp
+  "@\\(sql\\|data\\|val\\|org\\):\\([a-zA-Z_][a-zA-Z0-9_]*\\)"
+  "Regexp matching @type:name reference patterns.
+Group 1 captures the reference type (sql, data, val, org).
+Group 2 captures the reference name.")
+
+(defun duckdb-query--find-references-in-string (str-beg str-end)
+  "Find all references in string between STR-BEG and STR-END.
+Return list of plists, each with keys :type, :name, :beg, :end.
+STR-BEG and STR-END should include the quote characters."
+  (save-excursion
+    (goto-char (1+ str-beg))
+    (let ((content-end (1- str-end))
+          refs)
+      (while (re-search-forward duckdb-query--reference-regexp content-end t)
+        (push (list :type (intern (match-string 1))
+                    :name (intern (match-string 2))
+                    :beg (match-beginning 0)
+                    :end (match-end 0))
+              refs))
+      (nreverse refs))))
+
+;;;; Keyword Parameter Extraction
+
+(defconst duckdb-query--param-keywords
+  '(:sql :data :val :format :database :timeout :executor :output-via
+    :data-format :preserve-nested)
+  "Known `duckdb-query' keyword parameters.")
+
+(defconst duckdb-query--binding-keywords '(:sql :data :val)
+  "Parameters that define reference bindings.
+References of type @sql:, @data:, and @val: must have corresponding
+bindings in these parameters.")
+
+(defun duckdb-query--parse-params (form-beg form-end)
+  "Parse keyword parameters in `duckdb-query' form.
+FORM-BEG is the buffer position of the opening parenthesis.
+FORM-END is the buffer position after the closing parenthesis.
+
+Skip the function symbol and main SQL string, then collect all
+keyword-value pairs. Handle quoted and backquoted value forms.
+
+Return list of plists, each with keys:
+  :key     - keyword symbol (e.g., :sql, :data, :val)
+  :key-beg - buffer position of keyword start
+  :key-end - buffer position after keyword
+  :val-beg - buffer position of value start (including quote)
+  :val-end - buffer position after value
+
+Called by `duckdb-query--parse-at-point'."
+  (save-excursion
+    (goto-char form-beg)
+    (forward-char 1)
+    (duckdb-query--forward-sexp-safe)
+    (duckdb-query--skip-whitespace-and-comments)
+    (when (eq (char-after) duckdb-query--char-double-quote)
+      (duckdb-query--forward-sexp-safe))
+    (let (params)
+      (while (< (point) form-end)
+        (duckdb-query--skip-whitespace-and-comments)
+        (when (>= (point) form-end)
+          (cl-return))
+        (cond
+         ((eq (char-after) duckdb-query--char-colon)
+          (let ((key-beg (point)))
+            (if (looking-at ":\\([-a-zA-Z0-9]+\\)")
+                (let ((key (intern (match-string 0)))
+                      (key-end (match-end 0)))
+                  (goto-char key-end)
+                  (duckdb-query--skip-whitespace-and-comments)
+                  (when (< (point) form-end)
+                    (let ((val-beg (point)))
+                      (when (memq (char-after) (list duckdb-query--char-quote
+                                                     duckdb-query--char-backquote))
+                        (forward-char 1))
+                      (if (duckdb-query--forward-sexp-safe)
+                          (push (list :key key
+                                      :key-beg key-beg
+                                      :key-end key-end
+                                      :val-beg val-beg
+                                      :val-end (point))
+                                params)
+                        (goto-char key-end)))))
+              (forward-char 1))))
+         (t
+          (unless (duckdb-query--forward-sexp-safe)
+            (forward-char 1)))))
+      (nreverse params))))
+
+;;;; Binding Extraction
+
+(defun duckdb-query--extract-binding-names (val-beg val-end)
+  "Extract binding names from parameter value.
+VAL-BEG and VAL-END delimit the parameter value to parse.
+
+Handle quoted alists like ((name . value) ...) and backquoted
+forms like `((name . ,expr) ...).
+
+Skip nested forms like (sql ...) that are values, not bindings.
+A valid binding is a cons pair with symbol as car and dot separator.
+
+Return list of binding name symbols."
+  (save-excursion
+    (goto-char val-beg)
+    (duckdb-query--skip-whitespace-and-comments)
+    (when (memq (char-after) (list duckdb-query--char-quote
+                                   duckdb-query--char-backquote))
+      (forward-char 1))
+    (let (names)
+      (when (eq (char-after) duckdb-query--char-lparen)
+        (let ((list-end (save-excursion
+                          (when (duckdb-query--forward-sexp-safe)
+                            (1- (point))))))
+          (when (and list-end (< list-end val-end))
+            (forward-char 1)
+            (while (< (point) list-end)
+              (duckdb-query--skip-whitespace-and-comments)
+              (when (eq (char-after) duckdb-query--char-comma)
+                (forward-char 1)
+                (when (eq (char-after) duckdb-query--char-at)
+                  (forward-char 1)))
+              (duckdb-query--skip-whitespace-and-comments)
+              (when (and (< (point) list-end)
+                         (eq (char-after) duckdb-query--char-lparen))
+                (let ((pair-start (point)))
+                  (forward-char 1)
+                  (duckdb-query--skip-whitespace-and-comments)
+                  (when (looking-at "\\([a-zA-Z_][a-zA-Z0-9_-]*\\)")
+                    (let ((maybe-name (intern (match-string 1))))
+                      (goto-char (match-end 0))
+                      (duckdb-query--skip-whitespace-and-comments)
+                      (when (eq (char-after) duckdb-query--char-dot)
+                        (push maybe-name names))))
+                  (goto-char pair-start)))
+              (unless (duckdb-query--forward-sexp-safe)
+                (forward-char 1))))))
+      (nreverse names))))
+
+;;;; Parse Result Structure
+
+(cl-defstruct (duckdb-query-parse-result
+               (:constructor duckdb-query-parse-result--create)
+               (:copier nil))
+  "Result of parsing a `duckdb-query' form.
+
+Slots:
+  form-beg   - Start position of entire form.
+  form-end   - End position of entire form.
+  sql-beg    - Start position of main SQL string, or nil.
+  sql-end    - End position of main SQL string, or nil.
+  params     - List of parameter plists with positional info.
+  bindings   - Alist mapping parameter keywords to binding names.
+  references - List of reference plists with type, name, position, context."
+  (form-beg nil :documentation "Start of duckdb-query form.")
+  (form-end nil :documentation "End of duckdb-query form.")
+  (sql-beg nil :documentation "Start of main SQL string.")
+  (sql-end nil :documentation "End of main SQL string.")
+  (params nil :documentation "List of parameter plists.")
+  (bindings nil :documentation "Alist of (TYPE . (NAME ...)) for defined bindings.")
+  (references nil :documentation "List of reference plists with :type :name :beg :end :context."))
+
+;;;; Complete Form Parser
+
+(defun duckdb-query--parse-at-point ()
+  "Parse `duckdb-query' form at point.
+Return `duckdb-query-parse-result' struct containing form bounds,
+SQL string bounds, parameters, bindings, and references.
+
+Return nil if point is not inside a `duckdb-query' form.
+
+Parse extracts:
+- Form boundaries for overlay/fontification scope
+- Main SQL string position for reference detection
+- Keyword parameters with their positions
+- Binding names from :sql, :data, :val parameters
+- All @type:name references with their contexts"
+  (when-let ((form-bounds (duckdb-query--find-enclosing-form)))
+    (let* ((form-beg (car form-bounds))
+           (form-end (cdr form-bounds))
+           sql-beg sql-end
+           params bindings all-refs)
+      (save-excursion
+        (goto-char form-beg)
+        (forward-char 1)
+        (duckdb-query--forward-sexp-safe)
+        (duckdb-query--skip-whitespace-and-comments)
+        (when (eq (char-after) duckdb-query--char-double-quote)
+          (setq sql-beg (point))
+          (duckdb-query--forward-sexp-safe)
+          (setq sql-end (point))))
+      (setq params (duckdb-query--parse-params form-beg form-end))
+      (dolist (param params)
+        (let ((key (plist-get param :key)))
+          (when (memq key duckdb-query--binding-keywords)
+            (let ((names (duckdb-query--extract-binding-names
+                          (plist-get param :val-beg)
+                          (plist-get param :val-end))))
+              (when names
+                (push (cons key names) bindings))))))
+      (when (and sql-beg sql-end)
+        (dolist (ref (duckdb-query--find-references-in-string sql-beg sql-end))
+          (push (append ref (list :context :main-sql)) all-refs)))
+      (dolist (param params)
+        (let ((key (plist-get param :key))
+              (val-beg (plist-get param :val-beg))
+              (val-end (plist-get param :val-end)))
+          (dolist (str-bounds (duckdb-query--collect-strings-in-region val-beg val-end))
+            (dolist (ref (duckdb-query--find-references-in-string
+                          (car str-bounds) (cdr str-bounds)))
+              (push (append ref (list :context key)) all-refs)))))
+      (duckdb-query-parse-result--create
+       :form-beg form-beg
+       :form-end form-end
+       :sql-beg sql-beg
+       :sql-end sql-end
+       :params params
+       :bindings (nreverse bindings)
+       :references (nreverse all-refs)))))
+
+;;;; Validation
+
+(defun duckdb-query--validate-reference (ref bindings)
+  "Validate REF against BINDINGS.
+REF is a reference plist with :type, :name, :context.
+BINDINGS is an alist mapping keywords to lists of bound names.
+
+Return nil if reference is valid.
+Return error keyword if invalid:
+  :invalid-sql-in-val - @sql: reference inside :val parameter
+  :invalid-org-in-val - @org: reference inside :val parameter
+  :undefined          - reference name not found in bindings"
+  (let ((type (plist-get ref :type))
+        (name (plist-get ref :name))
+        (context (plist-get ref :context)))
+    (cond
+     ((and (eq type 'sql) (eq context :val))
+      :invalid-sql-in-val)
+     ((and (eq type 'org) (eq context :val))
+      :invalid-org-in-val)
+     ((not (memq name (cdr (assq (intern (format ":%s" type)) bindings))))
+      (if (and (eq type 'data)
+               (memq name (cdr (assq :data bindings))))
+          nil
+        :undefined))
+     (t nil))))
+
+(defun duckdb-query--validate-all-references (parse-result)
+  "Validate all references in PARSE-RESULT.
+PARSE-RESULT is a `duckdb-query-parse-result' struct.
+
+Return list of (REF . ERROR-TYPE) cons cells for invalid references.
+Return nil if all references are valid."
+  (let ((bindings (duckdb-query-parse-result-bindings parse-result))
+        invalid)
+    (dolist (ref (duckdb-query-parse-result-references parse-result))
+      (when-let ((err (duckdb-query--validate-reference ref bindings)))
+        (push (cons ref err) invalid)))
+    (nreverse invalid)))
+
+;;;; Buffer-Wide Parsing
+
+(defun duckdb-query-parse-buffer ()
+  "Parse all `duckdb-query' forms in current buffer.
+Return list of `duckdb-query-parse-result' structs, one per form.
+
+Skip forms that appear inside strings or comments."
+  (save-excursion
+    (goto-char (point-min))
+    (let (results)
+      (while (re-search-forward "(duckdb-query\\_>" nil t)
+        (goto-char (match-beginning 0))
+        (unless (duckdb-query--in-string-or-comment-p)
+          (when-let ((result (duckdb-query--parse-at-point)))
+            (push result results)
+            (goto-char (duckdb-query-parse-result-form-end result))))
+        (unless (eobp)
+          (forward-char 1)))
+      (nreverse results))))
+
+(defun duckdb-query-parse-buffer-with-validation ()
+  "Parse and validate all `duckdb-query' forms in current buffer.
+Return list of (PARSE-RESULT . INVALID-REFS) cons cells.
+
+PARSE-RESULT is a `duckdb-query-parse-result' struct.
+INVALID-REFS is a list of (REF . ERROR-TYPE) for invalid references,
+or nil if all references in that form are valid."
+  (mapcar (lambda (result)
+            (cons result (duckdb-query--validate-all-references result)))
+          (duckdb-query-parse-buffer)))
+
+;;; duckdb-query-parse.el ends here

--- a/duckdb-query-parse.el
+++ b/duckdb-query-parse.el
@@ -76,6 +76,24 @@
 (defconst duckdb-query--char-semicolon ?\;
   "Semicolon character, used as comment prefix.")
 
+;;;; Function Match Constant
+
+(defconst duckdb-query--query-function-regexp
+  (rx "(" (group "duckdb-query" (opt "-" (or "value" "row" "column"))) symbol-end)
+  "Regexp matching `duckdb-query' family function calls.
+
+Matches `duckdb-query', `duckdb-query-value', `duckdb-query-row',
+and `duckdb-query-column'.  All share the same argument structure:
+SQL string as first argument, keyword parameters for bindings.
+
+Group 1 captures the function name.
+
+Used by `duckdb-query--find-enclosing-form'.
+Used by `duckdb-query-parse-buffer'.
+Used by `duckdb-query-font-lock--find-form-start'.
+Used by `duckdb-query-font-lock--propertize'.")
+
+
 ;;;; Core Position Utilities
 
 (defsubst duckdb-query--in-string-p ()
@@ -124,24 +142,23 @@ Return new position on success, nil on scan error."
 ;;;; Form Location
 
 (defun duckdb-query--find-enclosing-form ()
-  "Find enclosing `duckdb-query' form containing point.
+  "Find enclosing `duckdb-query' family form containing point.
 Return (BEG . END) cons cell with form bounds, or nil if point
-is not inside a `duckdb-query' form.
+is not inside a recognized form.
 
-Checks if point is directly on a `duckdb-query' form first,
-then walks up the list structure checking each enclosing list."
+Matches functions listed in `duckdb-query--query-function-regexp'."
   (save-excursion
     (when-let ((str-start (duckdb-query--in-string-p)))
       (goto-char str-start))
     (catch 'found
-      ;; Check if directly on a duckdb-query form
-      (when (looking-at "(duckdb-query\\_>")
+      ;; Check if directly on a form
+      (when (looking-at duckdb-query--query-function-regexp)
         (let ((beg (point)))
           (when (duckdb-query--forward-sexp-safe)
             (throw 'found (cons beg (point))))))
       ;; Walk up list structure
       (while (duckdb-query--backward-up-list-safe)
-        (when (looking-at "(duckdb-query\\_>")
+        (when (looking-at duckdb-query--query-function-regexp)
           (let ((beg (point)))
             (when (duckdb-query--forward-sexp-safe)
               (throw 'found (cons beg (point)))))))
@@ -447,14 +464,14 @@ Return nil if all references are valid."
 ;;;; Buffer-Wide Parsing
 
 (defun duckdb-query-parse-buffer ()
-  "Parse all `duckdb-query' forms in current buffer.
+  "Parse all `duckdb-query' family forms in current buffer.
 Return list of `duckdb-query-parse-result' structs, one per form.
 
 Skip forms that appear inside strings or comments."
   (save-excursion
     (goto-char (point-min))
     (let (results)
-      (while (re-search-forward "(duckdb-query\\_>" nil t)
+      (while (re-search-forward duckdb-query--query-function-regexp nil t)
         (goto-char (match-beginning 0))
         (unless (duckdb-query--in-string-or-comment-p)
           (when-let ((result (duckdb-query--parse-at-point)))

--- a/duckdb-query-parse.el
+++ b/duckdb-query-parse.el
@@ -434,6 +434,9 @@ Return error keyword if invalid:
   :invalid-org-in-val - @org: reference inside :val parameter
   :undefined          - reference name not found in bindings
 
+Org references are always considered valid since they resolve
+from buffer content, not from parameter bindings.
+
 Called by `duckdb-query--validate-all-references'."
   (let ((type (plist-get ref :type))
         (name (plist-get ref :name))
@@ -443,6 +446,9 @@ Called by `duckdb-query--validate-all-references'."
       :invalid-sql-in-val)
      ((and (eq type 'org) (eq context :val))
       :invalid-org-in-val)
+     ;; Org references resolve from buffer content, not bindings
+     ((eq type 'org)
+      nil)
      ((not (memq name (cdr (assq (intern (format ":%s" type)) bindings))))
       (if (and (eq type 'data)
                (memq name (cdr (assq :data bindings))))

--- a/duckdb-query-parse.el
+++ b/duckdb-query-parse.el
@@ -475,4 +475,5 @@ or nil if all references in that form are valid."
             (cons result (duckdb-query--validate-all-references result)))
           (duckdb-query-parse-buffer)))
 
+(provide 'duckdb-query-parse)
 ;;; duckdb-query-parse.el ends here

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -2118,6 +2118,49 @@ Used in cleanup to avoid polluting session state."
      all-names
      "\n")))
 
+(defun duckdb-query--substitute-sql-refs (query sql-bindings)
+  "Replace @sql:NAME references in QUERY with SQL fragments.
+
+SQL-BINDINGS is alist of (name . sql-fragment) pairs.
+Each @sql:NAME reference is replaced with the corresponding fragment.
+Users should wrap references in parentheses when used as subqueries:
+  FROM (@sql:base)  =>  FROM (SELECT * FROM users)
+
+Returns modified query string.
+
+Signals =user-error' if @sql:NAME appears but NAME is not in SQL-BINDINGS.
+
+Example:
+  (duckdb-query--substitute-sql-refs
+   \"SELECT * FROM (@sql:base) WHERE x > 1\"
+   \\='((base . \"SELECT id, name FROM users\")))
+  => \"SELECT * FROM (SELECT id, name FROM users) WHERE x > 1\"
+
+Called by =duckdb-query' before other reference substitutions."
+  (let ((result query)
+        (sql-ref-pattern "@sql:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
+    ;; Collect all @sql: references first to validate
+    (let ((refs nil)
+          (temp-query query))
+      (while (string-match sql-ref-pattern temp-query)
+        (push (intern (match-string 1 temp-query)) refs)
+        (setq temp-query (substring temp-query (match-end 0))))
+      ;; Validate all references exist in bindings
+      (dolist (ref (nreverse refs))
+        (unless (assq ref sql-bindings)
+          (user-error "@sql:%s in query but '%s' not found in :sql parameter"
+                      ref ref))))
+    ;; Perform substitutions - direct text replacement, no wrapping
+    (dolist (binding sql-bindings)
+      (let* ((name (symbol-name (car binding)))
+             (fragment (cdr binding))
+             (pattern (format "@sql:%s\\b" (regexp-quote name))))
+        (setq result (replace-regexp-in-string
+                      pattern
+                      fragment
+                      result t t))))
+    result))
+
 
 ;;;; Main Entry Point
 
@@ -2131,14 +2174,66 @@ Used in cleanup to avoid polluting session state."
                               (data-format :json)
                               var
                               expr
+                              sql
                               preserve-nested
                               &allow-other-keys)
   "Execute QUERY and return results in FORMAT.
 
-QUERY is SQL string to execute.  May contain @SYMBOL references to
-Elisp data provided via DATA parameter, @org:NAME references to
-org tables, @var:NAME references to literal values, or @expr:NAME
-references to SQL expressions.
+QUERY is SQL string with optional inline references:
+
+  @org:name         Org table from current buffer
+  @org:file:name    Org table from FILE
+  @data:name        Elisp data from DATA parameter
+  @var:name         Literal value from VAR parameter
+  @expr:name        SQL expression from EXPR parameter
+  @sql:name         Query fragment from SQL parameter
+
+DATA binds Elisp data structures to @data: references:
+
+  Direct binding (referenced as @data or @data:data):
+    :data \\='(((id . 1) (name . \"Alice\")) ...)
+
+  Named bindings:
+    :data \\=`((users . ,user-data)
+            (orders . ,order-data))
+
+VAR binds literal values to @var:NAME references:
+
+  :var \\='((name . \"Alice\")
+         (age . 30)
+         (pattern . \"O'Brien%\"))
+
+  Values are converted to SQL literals with proper quoting.
+  Safe for user input - strings are escaped automatically.
+
+EXPR binds SQL expressions to @expr:NAME references:
+
+  :expr \\='((threshold . \"(SELECT AVG(score) FROM scores)\")
+          (ids . \"(SELECT list(id) FROM active_users)\"))
+
+  Values are passed through as raw SQL and executed.
+  Use for subqueries, aggregations, and computed values.
+
+SQL binds query fragments to @sql:NAME references:
+
+  :sql \\='((active_users . \"SELECT * FROM users WHERE status = \\='active\\='\")
+        (recent_orders . \"SELECT * FROM orders WHERE date > CURRENT_DATE - 30\"))
+
+  Fragments are substituted as parenthesized subqueries before other
+  reference types are processed.  This enables query composition without
+  string interpolation.
+
+  Unlike :var (which quotes values safely) and :expr (which evaluates
+  expressions), :sql performs direct text substitution.
+
+The reference type in QUERY must match the parameter:
+  - @var:x requires x to be in :var
+  - @expr:x requires x to be in :expr
+  - @sql:x requires x to be in :sql
+  Mismatches signal an error with a helpful message.
+
+Important: @expr: expressions execute BEFORE the main query.
+They cannot reference CTEs defined in the same query.
 
 DATABASE is optional database file path.  When nil, uses
 `duckdb-query-default-database' if set, otherwise in-memory database.
@@ -2195,45 +2290,9 @@ OUTPUT-VIA controls how results are transferred from DuckDB:
 When OUTPUT-VIA is `:file' and QUERY cannot be wrapped in
 COPY (DDL, DML, DESCRIBE statements), automatically falls back to `:pipe'.
 
-DATA enables querying Elisp data structures via @SYMBOL or @data:SYMBOL
-references.  Values must be actual data, not symbols; use backquote for
-variables:
-
-  Direct data (referenced as @data or @data:data):
-    :data \\='(((id . 1) (name . \"Alice\")) ...)
-
-  Named bindings (use backquote with comma for variables):
-    :data \\=`((orders . ,my-orders-var)
-            (users . ,my-users-var))
-
 DATA-FORMAT controls how DATA is serialized to temporary files:
   :json - JSON array via native `json-serialize' (default)
   :csv  - CSV format for compatibility
-
-VAR binds literal values to @var:NAME references:
-
-  :var \\='((name . \"Alice\")
-         (age . 30)
-         (pattern . \"O'Brien%\"))
-
-  Values are converted to SQL literals with proper quoting.
-  Safe for user input - strings are escaped automatically.
-
-EXPR binds SQL expressions to @expr:NAME references:
-
-  :expr \\='((threshold . \"(SELECT AVG(score) FROM scores)\")
-          (ids . \"(SELECT list(id) FROM active_users)\"))
-
-  Values are passed through as raw SQL and executed.
-  Use for subqueries, aggregations, and computed values.
-
-The reference type in QUERY must match the parameter:
-  - @var:x requires x to be in :var
-  - @expr:x requires x to be in :expr
-  Mismatches signal an error with a helpful message.
-
-Important: @expr: expressions execute BEFORE the main query.
-They cannot reference CTEs defined in the same query.
 
 PRESERVE-NESTED when non-nil and OUTPUT-VIA is `:pipe', wraps STRUCT,
 MAP, LIST, and ARRAY columns with to_json() so they return as nested
@@ -2262,22 +2321,33 @@ Examples:
   (duckdb-query \"SELECT * FROM scores WHERE val > @expr:avg\"
                 :expr \\='((avg . \"(SELECT AVG(val) FROM scores)\")))
 
-  ;; Combined variable and expression binding
+  ;; SQL fragment composition
+  (duckdb-query \"SELECT * FROM (@sql:base) WHERE active\"
+                :sql \\='((base . \"SELECT * FROM users\")))
+
+  ;; Combined bindings
   (duckdb-query
-   \"SELECT * FROM users
-    WHERE name LIKE @var:pattern
-      AND score > @expr:threshold\"
-   :var \\='((pattern . \"%smith%\"))
-   :expr \\='((threshold . \"(SELECT AVG(score) FROM users)\")))
+   \"SELECT * FROM (@sql:filtered)
+    WHERE score > @expr:threshold
+      AND name LIKE @var:pattern\"
+   :sql \\='((filtered . \"SELECT * FROM users WHERE status = \\='active\\='\"))
+   :expr \\='((threshold . \"(SELECT AVG(score) FROM users)\"))
+   :var \\='((pattern . \"%smith%\")))
 
 Uses `duckdb-query-execute' for execution dispatch.
+Uses `duckdb-query--substitute-sql-refs' for @sql: replacement.
 Uses `duckdb-query--substitute-data-refs' for @data: replacement.
 Uses `duckdb-query--substitute-org-refs' for @org: replacement.
 Uses `duckdb-query--substitute-var-refs' for @var: and @expr: replacement."
   (let* ((executor (duckdb-query--resolve-executor executor))
          (temp-files (make-hash-table :test 'eq))
+         ;; Step 0: Substitute @sql: references (before all others)
+         (sql-resolved-query (if sql
+                                 (duckdb-query--substitute-sql-refs query sql)
+                               query))
          ;; Step 1: Resolve @org: references
-         (org-resolved-query (duckdb-query--substitute-org-refs query temp-files))
+         (org-resolved-query (duckdb-query--substitute-org-refs
+                              sql-resolved-query temp-files))
          ;; Step 2: Substitute @data: and @ references
          (data-resolved-query (if data
                                   (duckdb-query--substitute-data-refs
@@ -2304,7 +2374,8 @@ Uses `duckdb-query--substitute-var-refs' for @var: and @expr: replacement."
                        (concat var-setup-sql effective-query)))
          (db (or database duckdb-query-default-database))
          (clean-args (cl-loop for (k v) on args by #'cddr
-                              unless (memq k '(:data :data-format :var :expr :preserve-nested))
+                              unless (memq k '(:data :data-format :var :expr
+                                               :sql :preserve-nested))
                               append (list k v)))
          (output nil))
     (unwind-protect

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -2015,89 +2015,108 @@ result))
 
 ;;;;; Variable Reference Substitution
 
-(defun duckdb-query--substitute-var-refs (query var-bindings)
+(defun duckdb-query--substitute-var-refs (query var-bindings expr-bindings)
   "Replace @var:NAME and @expr:NAME references in QUERY.
 
 QUERY is SQL string potentially containing references:
-  @var:NAME  - Literal value, quoted appropriately
-  @expr:NAME - SQL expression, passed through unquoted
+  @var:NAME  - Literal value from VAR-BINDINGS, quoted appropriately
+  @expr:NAME - SQL expression from EXPR-BINDINGS, passed through unquoted
 
-VAR-BINDINGS is alist of (name . value) pairs from :var parameter.
-Values are treated as literals for @var: references and as SQL
-expressions for @expr: references.
+VAR-BINDINGS is alist of (name . value) pairs for @var: references.
+EXPR-BINDINGS is alist of (name . sql-string) pairs for @expr: references.
 
 Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
-SUBSTITUTED-QUERY has references replaced with getvariable('NAME')
-VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
+  SUBSTITUTED-QUERY has references replaced with getvariable('NAME')
+  VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
+
+Signals error if:
+  - @var:NAME appears but NAME is not in VAR-BINDINGS
+  - @expr:NAME appears but NAME is not in EXPR-BINDINGS
+  - @var:NAME appears but NAME is in EXPR-BINDINGS (wrong parameter)
+  - @expr:NAME appears but NAME is in VAR-BINDINGS (wrong parameter)
 
 Example:
   (duckdb-query--substitute-var-refs
    \"SELECT @var:x, @expr:y\"
-   \\='((x . 100) (y . \"(SELECT 1 + 1)\")))
+   \\='((x . 100))
+   \\='((y . \"(SELECT 1 + 1)\")))
   => (\"SELECT getvariable('x'), getvariable('y')\"
       . \"SET VARIABLE x = 100;\\nSET VARIABLE y = (SELECT 1 + 1);\\n\")"
   (let ((result query)
         (setup-sql "")
-        (used-vars nil)
-        ;; Pattern for @var:NAME (literal binding)
+        (var-refs nil)
+        (expr-refs nil)
         (var-ref-pattern "@var:\\([a-zA-Z_][a-zA-Z0-9_]*\\)")
-        ;; Pattern for @expr:NAME (expression binding)
         (expr-ref-pattern "@expr:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
 
-    ;; Collect all @var: references and replace with getvariable()
+    ;; Collect all @var: references
     (let ((temp-result result))
       (while (string-match var-ref-pattern temp-result)
         (let ((var-name (match-string 1 temp-result)))
-          (push (cons (intern var-name) :literal) used-vars)
+          (push (intern var-name) var-refs)
           (setq temp-result (substring temp-result (match-end 0)))))
       (setq result (replace-regexp-in-string
                     var-ref-pattern
                     "getvariable('\\1')"
                     result t)))
 
-    ;; Collect all @expr: references and replace with getvariable()
+    ;; Collect all @expr: references
     (let ((temp-result result))
       (while (string-match expr-ref-pattern temp-result)
         (let ((var-name (match-string 1 temp-result)))
-          (push (cons (intern var-name) :expr) used-vars)
+          (push (intern var-name) expr-refs)
           (setq temp-result (substring temp-result (match-end 0)))))
       (setq result (replace-regexp-in-string
                     expr-ref-pattern
                     "getvariable('\\1')"
                     result t)))
 
-    ;; Build SET VARIABLE statements for used bindings
-    (dolist (used (nreverse used-vars))
-      (let* ((sym (car used))
-             (ref-type (cdr used))
-             (binding (assq sym var-bindings))
-             (name (symbol-name sym)))
-        (unless binding
-          (error "Variable @%s:%s referenced but not bound in :var parameter"
-                 (if (eq ref-type :expr) "expr" "var")
-                 name))
-        (let* ((value (cdr binding))
-               (sql-value (if (eq ref-type :expr)
-                              ;; Expression: pass through as-is
-                              value
-                            ;; Literal: convert to SQL literal
-                            (duckdb-query--value-to-sql-literal value))))
-          (setq setup-sql
-                (concat setup-sql
-                        (format "SET VARIABLE %s = %s;\n" name sql-value))))))
+    ;; Validate and build SET VARIABLE for @var: references
+    (dolist (sym (nreverse var-refs))
+      (let ((name (symbol-name sym)))
+        (cond
+         ((assq sym expr-bindings)
+          (error "@var:%s in query but '%s' is in :expr parameter (use @expr:%s or move to :var)"
+                 name name name))
+         ((not (assq sym var-bindings))
+          (error "@var:%s in query but '%s' not found in :var parameter" name name))
+         (t
+          (let ((value (cdr (assq sym var-bindings))))
+            (setq setup-sql
+                  (concat setup-sql
+                          (format "SET VARIABLE %s = %s;\n"
+                                  name
+                                  (duckdb-query--value-to-sql-literal value)))))))))
+
+    ;; Validate and build SET VARIABLE for @expr: references
+    (dolist (sym (nreverse expr-refs))
+      (let ((name (symbol-name sym)))
+        (cond
+         ((assq sym var-bindings)
+          (error "@expr:%s in query but '%s' is in :var parameter (use @var:%s or move to :expr)"
+                 name name name))
+         ((not (assq sym expr-bindings))
+          (error "@expr:%s in query but '%s' not found in :expr parameter" name name))
+         (t
+          (let ((value (cdr (assq sym expr-bindings))))
+            (setq setup-sql
+                  (concat setup-sql
+                          (format "SET VARIABLE %s = %s;\n" name value))))))))
 
     (cons result setup-sql)))
 
-(defun duckdb-query--var-reset-sql (var-bindings)
-  "Generate RESET VARIABLE statements for VAR-BINDINGS.
+(defun duckdb-query--var-reset-sql (var-bindings expr-bindings)
+  "Generate RESET VARIABLE statements for VAR-BINDINGS and EXPR-BINDINGS.
 
 Returns SQL string with RESET VARIABLE for each binding.
 Used in cleanup to avoid polluting session state."
-  (mapconcat
-   (lambda (binding)
-     (format "RESET VARIABLE %s;" (symbol-name (car binding))))
-   var-bindings
-   "\n"))
+  (let ((all-names (append (mapcar #'car var-bindings)
+                           (mapcar #'car expr-bindings))))
+    (mapconcat
+     (lambda (sym)
+       (format "RESET VARIABLE %s;" (symbol-name sym)))
+     all-names
+     "\n")))
 
 
 ;;;; Main Entry Point
@@ -2111,13 +2130,15 @@ Used in cleanup to avoid polluting session state."
                               data
                               (data-format :json)
                               var
+                              expr
                               preserve-nested
                               &allow-other-keys)
   "Execute QUERY and return results in FORMAT.
 
 QUERY is SQL string to execute.  May contain @SYMBOL references to
 Elisp data provided via DATA parameter, @org:NAME references to
-org tables, or @var:NAME references to SQL variables.
+org tables, @var:NAME references to literal values, or @expr:NAME
+references to SQL expressions.
 
 DATABASE is optional database file path.  When nil, uses
 `duckdb-query-default-database' if set, otherwise in-memory database.
@@ -2172,7 +2193,7 @@ OUTPUT-VIA controls how results are transferred from DuckDB:
                use with :preserve-nested for nested types)
 
 When OUTPUT-VIA is `:file' and QUERY cannot be wrapped in
-COPY \(DDL, DML, DESCRIBE statements), automatically falls back to `:pipe'.
+COPY (DDL, DML, DESCRIBE statements), automatically falls back to `:pipe'.
 
 DATA enables querying Elisp data structures via @SYMBOL or @data:SYMBOL
 references.  Values must be actual data, not symbols; use backquote for
@@ -2189,27 +2210,30 @@ DATA-FORMAT controls how DATA is serialized to temporary files:
   :json - JSON array via native `json-serialize' (default)
   :csv  - CSV format for compatibility
 
-VAR binds values to @var:NAME and @expr:NAME references:
+VAR binds literal values to @var:NAME references:
 
-  :var \\=`((threshold . 100)
-         (pattern . \"O'Brien%\")
-         (ids . \"(SELECT list(id) FROM active_users)\"))
+  :var \\='((name . \"Alice\")
+         (age . 30)
+         (pattern . \"O'Brien%\"))
 
-  @var:NAME  - Value is quoted as SQL literal (safe for user input)
-  @expr:NAME - Value is passed as SQL expression (for computed values)
+  Values are converted to SQL literals with proper quoting.
+  Safe for user input - strings are escaped automatically.
 
-Both reference types use getvariable() at runtime, but differ in how
-the value is set:
+EXPR binds SQL expressions to @expr:NAME references:
 
-  @var:threshold with value 100
-    => SET VARIABLE threshold = 100;
+  :expr \\='((threshold . \"(SELECT AVG(score) FROM scores)\")
+          (ids . \"(SELECT list(id) FROM active_users)\"))
 
-  @expr:ids with value \"(SELECT list(id) FROM t)\"
-    => SET VARIABLE ids = (SELECT list(id) FROM t);
+  Values are passed through as raw SQL and executed.
+  Use for subqueries, aggregations, and computed values.
 
-Use @var: for user-provided data (strings, numbers, etc.).
-Use @expr: when the value must be computed by DuckDB (subqueries,
-aggregations, dynamic lists).
+The reference type in QUERY must match the parameter:
+  - @var:x requires x to be in :var
+  - @expr:x requires x to be in :expr
+  Mismatches signal an error with a helpful message.
+
+Important: @expr: expressions execute BEFORE the main query.
+They cannot reference CTEs defined in the same query.
 
 PRESERVE-NESTED when non-nil and OUTPUT-VIA is `:pipe', wraps STRUCT,
 MAP, LIST, and ARRAY columns with to_json() so they return as nested
@@ -2230,22 +2254,26 @@ Examples:
   (duckdb-query \"SELECT COUNT(*) FROM users\" :format :single)
   ;; => 42
 
-  ;; Single row extraction
-  (duckdb-query \"SELECT * FROM users WHERE id = 1\" :format :row)
-  ;; => ((id . 1) (name . \"Alice\"))
-
-  ;; Column extraction
-  (duckdb-query \"SELECT name FROM users\" :format :column)
-  ;; => (\"Alice\" \"Bob\" \"Carol\")
-
   ;; Variable binding for safe parameterization
   (duckdb-query \"SELECT * FROM users WHERE age >= @var:min_age\"
                 :var \\='((min_age . 18)))
 
+  ;; Expression binding for computed values
+  (duckdb-query \"SELECT * FROM scores WHERE val > @expr:avg\"
+                :expr \\='((avg . \"(SELECT AVG(val) FROM scores)\")))
+
+  ;; Combined variable and expression binding
+  (duckdb-query
+   \"SELECT * FROM users
+    WHERE name LIKE @var:pattern
+      AND score > @expr:threshold\"
+   :var \\='((pattern . \"%smith%\"))
+   :expr \\='((threshold . \"(SELECT AVG(score) FROM users)\")))
+
 Uses `duckdb-query-execute' for execution dispatch.
 Uses `duckdb-query--substitute-data-refs' for @data: replacement.
 Uses `duckdb-query--substitute-org-refs' for @org: replacement.
-Uses `duckdb-query--substitute-var-refs' for @var: replacement."
+Uses `duckdb-query--substitute-var-refs' for @var: and @expr: replacement."
   (let* ((executor (duckdb-query--resolve-executor executor))
          (temp-files (make-hash-table :test 'eq))
          ;; Step 1: Resolve @org: references
@@ -2255,9 +2283,12 @@ Uses `duckdb-query--substitute-var-refs' for @var: replacement."
                                   (duckdb-query--substitute-data-refs
                                    org-resolved-query data data-format temp-files)
                                 org-resolved-query))
-         ;; Step 3: Substitute @var: references
-         (var-result (if var
-                         (duckdb-query--substitute-var-refs data-resolved-query var)
+         ;; Step 3: Substitute @var: and @expr: references
+         (var-result (if (or var expr)
+                         (duckdb-query--substitute-var-refs
+                          data-resolved-query
+                          (or var '())
+                          (or expr '()))
                        (cons data-resolved-query "")))
          (substituted-query (car var-result))
          (var-setup-sql (cdr var-result))
@@ -2273,7 +2304,7 @@ Uses `duckdb-query--substitute-var-refs' for @var: replacement."
                        (concat var-setup-sql effective-query)))
          (db (or database duckdb-query-default-database))
          (clean-args (cl-loop for (k v) on args by #'cddr
-                              unless (memq k '(:data :data-format :var :preserve-nested))
+                              unless (memq k '(:data :data-format :var :expr :preserve-nested))
                               append (list k v)))
          (output nil))
     (unwind-protect
@@ -2373,11 +2404,11 @@ Uses `duckdb-query--substitute-var-refs' for @var: replacement."
                ;; DDL/DML success - non-JSON, non-error output
                (t nil)))))
       ;; Cleanup: reset variables in session mode
-      (when (and var (eq executor :session))
+      (when (and (or var expr) (eq executor :session))
         (ignore-errors
           (duckdb-query-session-execute
            duckdb-query--current-session
-           (duckdb-query--var-reset-sql var)
+           (duckdb-query--var-reset-sql (or var '()) (or expr '()))
            5)))
       ;; Cleanup temp files
       (maphash (lambda (_sym file)

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -151,13 +151,13 @@ via `duckdb-query-with-database'.
 
 Nil means in-memory transient database.")
 
-(defvar duckdb-query--transient-database-p nil
-  "Non-nil when inside `duckdb-query-with-transient-database' scope.
+(defvar duckdb-query--database-readonly nil
+  "When non-nil, CLI executor opens database in read-only mode.
 
-Used by CLI executor to default to writable mode, enabling database
-file creation.  Without this, the CLI executor defaults to read-only
-mode when a database path is specified, which fails for non-existent
-databases.")
+Bound by `duckdb-query-with-database' when :readonly t is specified
+in the spec list.  Consulted by `duckdb-query-execute' :cli method.
+
+Also see `duckdb-query-with-database'.")
 
 ;;;; Internal Extraction Functions
 (defun duckdb-query--extract-single (rows format-name)
@@ -451,6 +451,8 @@ Within session scope (inside `duckdb-query-with-session'):
 
 Outside session scope:
   Binds `duckdb-query-default-database' to database path for BODY.
+  When :readonly t specified, binds `duckdb-query--database-readonly'
+  so CLI executor opens database in read-only mode.
   All `duckdb-query' calls use database unless overridden by
   explicit :database parameter.
 
@@ -514,7 +516,8 @@ Also see `duckdb-query-session-attach' for manual attachment."
                  (duckdb-query-session-detach
                   duckdb-query--current-session
                   ,alias-sym))))
-         (let ((duckdb-query-default-database ,db-sym))
+         (let ((duckdb-query-default-database ,db-sym)
+               (duckdb-query--database-readonly ,readonly-sym))
            ,@body)))))
 
 (defmacro duckdb-query-with-transient-database (&rest body)
@@ -529,7 +532,6 @@ Outside session scope:
   Bind `duckdb-query-default-database' to temp file.
   All `duckdb-query' calls use this database via CLI executor.
   Each query spawns new DuckDB process but shares database state.
-  Queries default to writable mode to enable database creation.
 
 Within session scope (inside `duckdb-query-with-session'):
   ATTACH temp database to session as writable.
@@ -590,10 +592,9 @@ Also see `duckdb-query-with-transient-session' for ephemeral sessions."
                   ,alias-var))
                (when (file-exists-p ,db-var)
                  (delete-file ,db-var))))
-         ;; CLI context: bind default database with transient flag
+         ;; CLI context: bind default database
          (unwind-protect
-             (let ((duckdb-query-default-database ,db-var)
-                   (duckdb-query--transient-database-p t))
+             (let ((duckdb-query-default-database ,db-var))
                ,@body)
            (when (file-exists-p ,db-var)
              (delete-file ,db-var)))))))
@@ -803,8 +804,7 @@ Called by `duckdb-query-execute' `:cli' method when file output is viable."
 
 Supported ARGS:
   :database     - Database file path (nil for in-memory)
-  :readonly     - Open database read-only (default t when :database provided,
-                  except nil when inside `duckdb-query-with-transient-database')
+  :readonly     - Open database read-only (default nil)
   :timeout      - Execution timeout in seconds
   :output-via   - Output strategy: `:file' (default) or `:pipe'
   :output-mode  - DuckDB output mode (default \\='json for pipe mode)
@@ -825,10 +825,8 @@ for DDL, DML, DESCRIBE, and other non-SELECT statements.
 Return JSON string from DuckDB output.
 Signal error on execution failure after fallback."
   (let* ((database (plist-get args :database))
-         (readonly (if (plist-member args :readonly)
-                       (plist-get args :readonly)
-                     ;; Default: writable for transient databases, readonly for others
-                     (and database (not duckdb-query--transient-database-p))))
+         (readonly (or (plist-get args :readonly)
+                       duckdb-query--database-readonly))
          (timeout (or (plist-get args :timeout)
                       duckdb-query-default-timeout))
          (output-via (or (plist-get args :output-via) :file))

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -308,6 +308,256 @@ Also see `duckdb-query' with :format :columnar for multiple columns."
      (t
       (append col-data nil)))))
 
+;;;; Type String Parsing
+
+(defun duckdb-query--tokenize-type (str)
+  "Tokenize DuckDB type string STR into a list of tokens.
+
+Tokens are strings: identifiers, numbers, and single punctuation
+characters from the set ( ) , [ ].
+
+Double-quoted identifiers are returned without quotes, with
+escaped double quotes (\"\" -> \") resolved.
+
+Return list of token strings.
+
+Called by `duckdb-query-parse-type'."
+  (let ((pos 0)
+        (len (length str))
+        (tokens nil))
+    (while (< pos len)
+      (let ((ch (aref str pos)))
+        (cond
+         ;; Whitespace
+         ((memq ch '(?\s ?\t ?\n ?\r))
+          (setq pos (1+ pos)))
+         ;; Punctuation
+         ((memq ch '(?\( ?\) ?, ?\[ ?\]))
+          (push (string ch) tokens)
+          (setq pos (1+ pos)))
+         ;; Quoted identifier
+         ((eq ch ?\")
+          (let ((end (1+ pos))
+                (chars nil)
+                (done nil))
+            (while (and (< end len) (not done))
+              (let ((c (aref str end)))
+                (cond
+                 ((and (eq c ?\")
+                       (< (1+ end) len)
+                       (eq (aref str (1+ end)) ?\"))
+                  (push ?\" chars)
+                  (setq end (+ end 2)))
+                 ((eq c ?\")
+                  (setq end (1+ end))
+                  (setq done t))
+                 (t
+                  (push c chars)
+                  (setq end (1+ end))))))
+            (push (apply #'string (nreverse chars)) tokens)
+            (setq pos end)))
+         ;; Identifier or number
+         (t
+          (let ((end pos))
+            (while (and (< end len)
+                        (let ((c (aref str end)))
+                          (or (and (>= c ?A) (<= c ?Z))
+                              (and (>= c ?a) (<= c ?z))
+                              (and (>= c ?0) (<= c ?9))
+                              (eq c ?_))))
+              (setq end (1+ end)))
+            (when (= end pos)
+              (error "Unexpected character %c at position %d in type: %s"
+                     ch pos str))
+            (push (substring str pos end) tokens)
+            (setq pos end))))))
+    (nreverse tokens)))
+
+(defun duckdb-query--parse-type-from-tokens (tokens)
+  "Parse one type from TOKENS, return (PARSED-TYPE . REMAINING-TOKENS).
+
+Dispatch on uppercase type name to STRUCT/UNION field parsing,
+MAP/LIST/ARRAY sub-type parsing, parameterized scalar parsing,
+or plain scalar symbol.
+
+Called by `duckdb-query-parse-type'.
+Recursively called for nested types."
+  (unless tokens
+    (error "Unexpected end of type tokens"))
+  (let* ((name (pop tokens))
+         (upper (upcase name)))
+    (cond
+     ;; STRUCT(field type, ...) or UNION(field type, ...)
+     ((and (member upper '("STRUCT" "UNION"))
+           (equal (car tokens) "("))
+      (pop tokens)
+      (let ((fields nil))
+        (while (not (equal (car tokens) ")"))
+          (unless tokens (error "Unclosed %s" upper))
+          (let* ((fname (pop tokens))
+                 (sub (duckdb-query--parse-type-from-tokens tokens))
+                 (ftype (car sub)))
+            (setq tokens (cdr sub))
+            (push (cons (intern fname) ftype) fields)
+            (when (equal (car tokens) ",")
+              (pop tokens))))
+        (pop tokens)
+        (duckdb-query--parse-type-suffixes
+         (cons (intern upper) (nreverse fields)) tokens)))
+
+     ;; MAP(key, value)
+     ((and (string= upper "MAP") (equal (car tokens) "("))
+      (pop tokens)
+      (let* ((k (duckdb-query--parse-type-from-tokens tokens))
+             (_ (progn (setq tokens (cdr k))
+                       (unless (equal (pop tokens) ",")
+                         (error "Expected ',' in MAP"))))
+             (v (duckdb-query--parse-type-from-tokens tokens)))
+        (setq tokens (cdr v))
+        (unless (equal (pop tokens) ")")
+          (error "Expected ')' closing MAP"))
+        (duckdb-query--parse-type-suffixes
+         (list 'MAP (car k) (car v)) tokens)))
+
+     ;; LIST(type)
+     ((and (string= upper "LIST") (equal (car tokens) "("))
+      (pop tokens)
+      (let ((inner (duckdb-query--parse-type-from-tokens tokens)))
+        (setq tokens (cdr inner))
+        (unless (equal (pop tokens) ")")
+          (error "Expected ')' closing LIST"))
+        (duckdb-query--parse-type-suffixes
+         (list 'LIST (car inner)) tokens)))
+
+     ;; ARRAY(type, N)
+     ((and (string= upper "ARRAY") (equal (car tokens) "("))
+      (pop tokens)
+      (let ((inner (duckdb-query--parse-type-from-tokens tokens)))
+        (setq tokens (cdr inner))
+        (unless (equal (pop tokens) ",")
+          (error "Expected ',' in ARRAY"))
+        (let ((n (string-to-number (pop tokens))))
+          (unless (equal (pop tokens) ")")
+            (error "Expected ')' closing ARRAY"))
+          (duckdb-query--parse-type-suffixes
+           (list 'ARRAY (car inner) n) tokens))))
+
+     ;; Parameterized scalar: DECIMAL(18,3), VARCHAR(255)
+     ((equal (car tokens) "(")
+      (pop tokens)
+      (let ((params nil))
+        (while (not (equal (car tokens) ")"))
+          (unless tokens (error "Unclosed parameter list"))
+          (push (string-to-number (pop tokens)) params)
+          (when (equal (car tokens) ",")
+            (pop tokens)))
+        (pop tokens)
+        (duckdb-query--parse-type-suffixes
+         (cons (intern upper) (nreverse params)) tokens)))
+
+     ;; Plain scalar
+     (t
+      (duckdb-query--parse-type-suffixes (intern upper) tokens)))))
+
+(defun duckdb-query--parse-type-suffixes (parsed tokens)
+  "Wrap PARSED with LIST or ARRAY for trailing [] or [N] in TOKENS.
+
+Return (FINAL-PARSED . REMAINING-TOKENS).
+
+Called after each type parse to handle suffix notation."
+  (while (equal (car tokens) "[")
+    (pop tokens)
+    (if (equal (car tokens) "]")
+        (progn (pop tokens)
+               (setq parsed (list 'LIST parsed)))
+      (let ((n (string-to-number (pop tokens))))
+        (unless (equal (pop tokens) "]")
+          (error "Expected ']'"))
+        (setq parsed (list 'ARRAY parsed n)))))
+  (cons parsed tokens))
+
+(defun duckdb-query-parse-type (type-string)
+  "Parse DuckDB TYPE-STRING into structured Elisp representation.
+
+TYPE-STRING is a DuckDB type string as returned by DESCRIBE or
+`duckdb-query-column-types'.
+
+Scalar types return as symbols.  Compound types return as lists:
+
+  \"INTEGER\"                   => INTEGER
+  \"DECIMAL(18,3)\"             => (DECIMAL 18 3)
+  \"VARCHAR[]\"                 => (LIST VARCHAR)
+  \"INTEGER[3]\"                => (ARRAY INTEGER 3)
+  \"STRUCT(x INT, y VARCHAR)\"  => (STRUCT (x . INT) (y . VARCHAR))
+  \"MAP(VARCHAR, INTEGER)\"     => (MAP VARCHAR INTEGER)
+  \"UNION(num INT, str TEXT)\"  => (UNION (num . INT) (str . TEXT))
+
+Nested types parse recursively.  Extension and user-defined types
+return as symbols.
+
+Signal error for malformed type strings.
+
+Uses `duckdb-query--tokenize-type' for lexing.
+Uses `duckdb-query--parse-type-from-tokens' for parsing.
+Also see `duckdb-query-column-types' with :format :parsed.
+Also see `duckdb-query-type-to-json' for JSON conversion."
+  (let* ((tokens (duckdb-query--tokenize-type type-string))
+         (result (duckdb-query--parse-type-from-tokens tokens)))
+    (when (cdr result)
+      (error "Trailing tokens in type string: %S" (cdr result)))
+    (car result)))
+
+(defun duckdb-query-type-to-json (parsed-type)
+  "Convert PARSED-TYPE to a JSON-serializable Elisp structure.
+
+PARSED-TYPE is the output of `duckdb-query-parse-type'.
+
+Scalar types become strings.  Compound types become alists with
+symbol keys suitable for `json-serialize':
+
+  INTEGER              => \"INTEGER\"
+  (DECIMAL 18 3)       => ((type . \"DECIMAL\") (params . [18 3]))
+  (LIST VARCHAR)       => ((type . \"LIST\") (element . \"VARCHAR\"))
+  (ARRAY INT 3)        => ((type . \"ARRAY\") (element . \"INT\") (size . 3))
+  (MAP K V)            => ((type . \"MAP\") (key . K) (value . V))
+  (STRUCT (f . T) ...) => ((type . \"STRUCT\") (fields . [field ...]))
+  (UNION (f . T) ...)  => ((type . \"UNION\") (fields . [field ...]))
+
+Each STRUCT/UNION field becomes ((name . \"f\") (type . ...)).
+
+Also see `duckdb-query-parse-type'.
+Also see `duckdb-query-column-types' with :format :json."
+  (cond
+   ((symbolp parsed-type)
+    (symbol-name parsed-type))
+   ((consp parsed-type)
+    (let ((kind (car parsed-type)))
+      (pcase kind
+        ((or 'STRUCT 'UNION)
+         `((type . ,(symbol-name kind))
+           (fields . ,(vconcat
+                       (mapcar
+                        (lambda (field)
+                          `((name . ,(symbol-name (car field)))
+                            (type . ,(duckdb-query-type-to-json
+                                      (cdr field)))))
+                        (cdr parsed-type))))))
+        ('LIST
+         `((type . "LIST")
+           (element . ,(duckdb-query-type-to-json (cadr parsed-type)))))
+        ('ARRAY
+         `((type . "ARRAY")
+           (element . ,(duckdb-query-type-to-json (cadr parsed-type)))
+           (size . ,(caddr parsed-type))))
+        ('MAP
+         `((type . "MAP")
+           (key . ,(duckdb-query-type-to-json (cadr parsed-type)))
+           (value . ,(duckdb-query-type-to-json (caddr parsed-type)))))
+        (_
+         `((type . ,(symbol-name kind))
+           (params . ,(vconcat (cdr parsed-type))))))))
+   (t (error "Unexpected parsed type: %S" parsed-type))))
+
 ;;;; Schema Introspection
 
 (defun duckdb-query-describe (source &rest args)
@@ -403,27 +653,73 @@ Also see `duckdb-query-column-types' for name-to-type mapping."
           (apply #'duckdb-query-describe source args)))
 
 (defun duckdb-query-column-types (source &rest args)
-  "Return alist mapping column names to DuckDB types for SOURCE.
+  "Return column name-to-type mapping for SOURCE.
 
 SOURCE can be table name, file path, URL, or SELECT query.
-ARGS are passed to `duckdb-query-describe'.
 
-Return alist of (NAME . TYPE) pairs where NAME is column name
-string and TYPE is DuckDB type string.
+ARGS are keyword arguments:
+  :format - Output format for type values (default :raw)
+
+FORMAT controls the representation of type values:
+
+  :raw     Alist of (NAME-STRING . TYPE-STRING) pairs.
+           Type strings are DuckDB's canonical text representation.
+           This is the default.
+
+  :parsed  Alist of (NAME-STRING . PARSED-TYPE) pairs.
+           Type strings are parsed into structured Elisp via
+           `duckdb-query-parse-type'.  Scalars become symbols,
+           compound types become nested lists.
+
+  :json    JSON string representing the full schema as a JSON
+           array of objects, each with \"name\" and \"type\" keys.
+           Uses `duckdb-query-type-to-json' and `json-serialize'.
+
+Other ARGS are passed to `duckdb-query-describe'.
 
 Example:
 
-  (duckdb-query-column-types \"users\")
-  ;; => ((\"id\" . \"INTEGER\")
-  ;;     (\"name\" . \"VARCHAR\")
-  ;;     (\"created_at\" . \"TIMESTAMP\"))
+  (duckdb-query-column-types \"SELECT 1 AS id, 'x' AS name\")
+  ;; => ((\"id\" . \"INTEGER\") (\"name\" . \"VARCHAR\"))
+
+  (duckdb-query-column-types
+   \"SELECT {'x': 1} AS pt\" :format :parsed)
+  ;; => ((\"pt\" . (STRUCT (x . INTEGER))))
+
+  (duckdb-query-column-types
+   \"SELECT 1 AS id\" :format :json)
+  ;; => \"[{\\\"name\\\":\\\"id\\\",\\\"type\\\":\\\"INTEGER\\\"}]\"
 
 Also see `duckdb-query-describe' for full column metadata.
-Also see `duckdb-query-columns' for just column names."
-  (mapcar (lambda (row)
-            (cons (cdr (assq 'column_name row))
-                  (cdr (assq 'column_type row))))
-          (apply #'duckdb-query-describe source args)))
+Also see `duckdb-query-columns' for just column names.
+Also see `duckdb-query-parse-type' for parsing individual types.
+Also see `duckdb-query-type-to-json' for JSON conversion."
+  (let* ((format (or (plist-get args :format) :raw))
+         (clean-args (cl-loop for (k v) on args by #'cddr
+                              unless (eq k :format)
+                              append (list k v)))
+         (raw (mapcar (lambda (row)
+                        (cons (cdr (assq 'column_name row))
+                              (cdr (assq 'column_type row))))
+                      (apply #'duckdb-query-describe source clean-args))))
+    (pcase format
+      (:raw raw)
+      (:parsed
+       (mapcar (lambda (pair)
+                 (cons (car pair)
+                       (duckdb-query-parse-type (cdr pair))))
+               raw))
+      (:json
+       (json-serialize
+        (vconcat
+         (mapcar (lambda (pair)
+                   `((name . ,(car pair))
+                     (type . ,(duckdb-query-type-to-json
+                               (duckdb-query-parse-type (cdr pair))))))
+                 raw))))
+      (_
+       (error "Unknown column-types format: %s.  Valid: :raw :parsed :json"
+              format)))))
 
 ;;;; Context Management Macro
 

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -217,7 +217,7 @@ Example:
   ;; => ((id . 1) (name . \"Alice\") (email . \"alice@example.com\"))
 
   (duckdb-query-row \"SELECT name, email FROM users WHERE id = @var:uid\"
-                    :var \\='((uid . 42)))
+                    :val \\='((uid . 42)))
   ;; => ((name . \"Bob\") (email . \"bob@example.com\"))
 
 Also see `duckdb-query-value' for scalar extraction.
@@ -1961,7 +1961,7 @@ Shorthand form (existing behavior):
 \"SELECT * FROM @users\"
 
 Both forms are equivalent.  Explicit form recommended when query
-contains @org: and @var: references for visual consistency."
+contains @org: and @val: references for visual consistency."
 (let ((result query)
     (serializer (if (eq data-format :csv)
                     #'duckdb-query--alist-to-csv-file
@@ -2015,14 +2015,14 @@ result))
 
 ;;;;; Variable Reference Substitution
 
-(defun duckdb-query--substitute-var-refs (query var-bindings expr-bindings)
-  "Replace @var:NAME and @expr:NAME references in QUERY.
+(defun duckdb-query--substitute-var-refs (query val-bindings expr-bindings)
+  "Replace @val:NAME and @expr:NAME references in QUERY.
 
 QUERY is SQL string potentially containing references:
-  @var:NAME  - Literal value from VAR-BINDINGS, quoted appropriately
+  @val:NAME  - Literal value from VAL-BINDINGS, quoted appropriately
   @expr:NAME - SQL expression from EXPR-BINDINGS, passed through unquoted
 
-VAR-BINDINGS is alist of (name . value) pairs for @var: references.
+VAL-BINDINGS is alist of (name . value) pairs for @val: references.
 EXPR-BINDINGS is alist of (name . sql-string) pairs for @expr: references.
 
 Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
@@ -2030,33 +2030,33 @@ Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
   VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
 
 Signals error if:
-  - @var:NAME appears but NAME is not in VAR-BINDINGS
+  - @val:NAME appears but NAME is not in VAL-BINDINGS
   - @expr:NAME appears but NAME is not in EXPR-BINDINGS
-  - @var:NAME appears but NAME is in EXPR-BINDINGS (wrong parameter)
-  - @expr:NAME appears but NAME is in VAR-BINDINGS (wrong parameter)
+  - @val:NAME appears but NAME is in EXPR-BINDINGS (wrong parameter)
+  - @expr:NAME appears but NAME is in VAL-BINDINGS (wrong parameter)
 
 Example:
   (duckdb-query--substitute-var-refs
-   \"SELECT @var:x, @expr:y\"
+   \"SELECT @val:x, @expr:y\"
    \\='((x . 100))
    \\='((y . \"(SELECT 1 + 1)\")))
   => (\"SELECT getvariable('x'), getvariable('y')\"
       . \"SET VARIABLE x = 100;\\nSET VARIABLE y = (SELECT 1 + 1);\\n\")"
   (let ((result query)
         (setup-sql "")
-        (var-refs nil)
+        (val-refs nil)
         (expr-refs nil)
-        (var-ref-pattern "@var:\\([a-zA-Z_][a-zA-Z0-9_]*\\)")
+        (val-ref-pattern "@val:\\([a-zA-Z_][a-zA-Z0-9_]*\\)")
         (expr-ref-pattern "@expr:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
 
-    ;; Collect all @var: references
+    ;; Collect all @val: references
     (let ((temp-result result))
-      (while (string-match var-ref-pattern temp-result)
+      (while (string-match val-ref-pattern temp-result)
         (let ((var-name (match-string 1 temp-result)))
-          (push (intern var-name) var-refs)
+          (push (intern var-name) val-refs)
           (setq temp-result (substring temp-result (match-end 0)))))
       (setq result (replace-regexp-in-string
-                    var-ref-pattern
+                    val-ref-pattern
                     "getvariable('\\1')"
                     result t)))
 
@@ -2071,17 +2071,17 @@ Example:
                     "getvariable('\\1')"
                     result t)))
 
-    ;; Validate and build SET VARIABLE for @var: references
-    (dolist (sym (nreverse var-refs))
+    ;; Validate and build SET VARIABLE for @val: references
+    (dolist (sym (nreverse val-refs))
       (let ((name (symbol-name sym)))
         (cond
          ((assq sym expr-bindings)
-          (error "@var:%s in query but '%s' is in :expr parameter (use @expr:%s or move to :var)"
+          (error "@val:%s in query but '%s' is in :expr parameter (use @expr:%s or move to :val)"
                  name name name))
-         ((not (assq sym var-bindings))
-          (error "@var:%s in query but '%s' not found in :var parameter" name name))
+         ((not (assq sym val-bindings))
+          (error "@val:%s in query but '%s' not found in :val parameter" name name))
          (t
-          (let ((value (cdr (assq sym var-bindings))))
+          (let ((value (cdr (assq sym val-bindings))))
             (setq setup-sql
                   (concat setup-sql
                           (format "SET VARIABLE %s = %s;\n"
@@ -2092,8 +2092,8 @@ Example:
     (dolist (sym (nreverse expr-refs))
       (let ((name (symbol-name sym)))
         (cond
-         ((assq sym var-bindings)
-          (error "@expr:%s in query but '%s' is in :var parameter (use @var:%s or move to :expr)"
+         ((assq sym val-bindings)
+          (error "@expr:%s in query but '%s' is in :val parameter (use @val:%s or move to :expr)"
                  name name name))
          ((not (assq sym expr-bindings))
           (error "@expr:%s in query but '%s' not found in :expr parameter" name name))
@@ -2105,12 +2105,12 @@ Example:
 
     (cons result setup-sql)))
 
-(defun duckdb-query--var-reset-sql (var-bindings expr-bindings)
-  "Generate RESET VARIABLE statements for VAR-BINDINGS and EXPR-BINDINGS.
+(defun duckdb-query--var-reset-sql (val-bindings expr-bindings)
+  "Generate RESET VARIABLE statements for VAL-BINDINGS and EXPR-BINDINGS.
 
 Returns SQL string with RESET VARIABLE for each binding.
 Used in cleanup to avoid polluting session state."
-  (let ((all-names (append (mapcar #'car var-bindings)
+  (let ((all-names (append (mapcar #'car val-bindings)
                            (mapcar #'car expr-bindings))))
     (mapconcat
      (lambda (sym)
@@ -2172,7 +2172,7 @@ Called by =duckdb-query' before other reference substitutions."
                               (output-via :file)
                               data
                               (data-format :json)
-                              var
+                              val
                               expr
                               sql
                               preserve-nested
@@ -2184,7 +2184,7 @@ QUERY is SQL string with optional inline references:
   @org:name         Org table from current buffer
   @org:file:name    Org table from FILE
   @data:name        Elisp data from DATA parameter
-  @var:name         Literal value from VAR parameter
+  @val:name         Literal value from VAL parameter
   @expr:name        SQL expression from EXPR parameter
   @sql:name         Query fragment from SQL parameter
 
@@ -2197,9 +2197,9 @@ DATA binds Elisp data structures to @data: references:
     :data \\=`((users . ,user-data)
             (orders . ,order-data))
 
-VAR binds literal values to @var:NAME references:
+VAL binds literal values to @val:NAME references:
 
-  :var \\='((name . \"Alice\")
+  :val \\='((name . \"Alice\")
          (age . 30)
          (pattern . \"O'Brien%\"))
 
@@ -2223,11 +2223,11 @@ SQL binds query fragments to @sql:NAME references:
   reference types are processed.  This enables query composition without
   string interpolation.
 
-  Unlike :var (which quotes values safely) and :expr (which evaluates
+  Unlike :val (which quotes values safely) and :expr (which evaluates
   expressions), :sql performs direct text substitution.
 
 The reference type in QUERY must match the parameter:
-  - @var:x requires x to be in :var
+  - @val:x requires x to be in :val
   - @expr:x requires x to be in :expr
   - @sql:x requires x to be in :sql
   Mismatches signal an error with a helpful message.
@@ -2314,8 +2314,8 @@ Examples:
   ;; => 42
 
   ;; Variable binding for safe parameterization
-  (duckdb-query \"SELECT * FROM users WHERE age >= @var:min_age\"
-                :var \\='((min_age . 18)))
+  (duckdb-query \"SELECT * FROM users WHERE age >= @val:min_age\"
+                :val \\='((min_age . 18)))
 
   ;; Expression binding for computed values
   (duckdb-query \"SELECT * FROM scores WHERE val > @expr:avg\"
@@ -2329,16 +2329,16 @@ Examples:
   (duckdb-query
    \"SELECT * FROM (@sql:filtered)
     WHERE score > @expr:threshold
-      AND name LIKE @var:pattern\"
+      AND name LIKE @val:pattern\"
    :sql \\='((filtered . \"SELECT * FROM users WHERE status = \\='active\\='\"))
    :expr \\='((threshold . \"(SELECT AVG(score) FROM users)\"))
-   :var \\='((pattern . \"%smith%\")))
+   :val \\='((pattern . \"%smith%\")))
 
 Uses `duckdb-query-execute' for execution dispatch.
 Uses `duckdb-query--substitute-sql-refs' for @sql: replacement.
 Uses `duckdb-query--substitute-data-refs' for @data: replacement.
 Uses `duckdb-query--substitute-org-refs' for @org: replacement.
-Uses `duckdb-query--substitute-var-refs' for @var: and @expr: replacement."
+Uses `duckdb-query--substitute-var-refs' for @val: and @expr: replacement."
   (let* ((executor (duckdb-query--resolve-executor executor))
          (temp-files (make-hash-table :test 'eq))
          ;; Step 0: Substitute @sql: references (before all others)
@@ -2353,15 +2353,15 @@ Uses `duckdb-query--substitute-var-refs' for @var: and @expr: replacement."
                                   (duckdb-query--substitute-data-refs
                                    org-resolved-query data data-format temp-files)
                                 org-resolved-query))
-         ;; Step 3: Substitute @var: and @expr: references
-         (var-result (if (or var expr)
+         ;; Step 3: Substitute @val: and @expr: references
+         (val-result (if (or val expr)
                          (duckdb-query--substitute-var-refs
                           data-resolved-query
-                          (or var '())
+                          (or val '())
                           (or expr '()))
                        (cons data-resolved-query "")))
-         (substituted-query (car var-result))
-         (var-setup-sql (cdr var-result))
+         (substituted-query (car val-result))
+         (val-setup-sql (cdr val-result))
          ;; Step 4: Wrap for nested preservation if needed
          (effective-query (if (and preserve-nested
                                    (or (eq output-via :pipe)
@@ -2369,12 +2369,12 @@ Uses `duckdb-query--substitute-var-refs' for @var: and @expr: replacement."
                               (duckdb-query--wrap-nested-columns substituted-query)
                             substituted-query))
          ;; Combine variable setup with query
-         (full-query (if (string-empty-p var-setup-sql)
+         (full-query (if (string-empty-p val-setup-sql)
                          effective-query
-                       (concat var-setup-sql effective-query)))
+                       (concat val-setup-sql effective-query)))
          (db (or database duckdb-query-default-database))
          (clean-args (cl-loop for (k v) on args by #'cddr
-                              unless (memq k '(:data :data-format :var :expr
+                              unless (memq k '(:data :data-format :val :expr
                                                :sql :preserve-nested))
                               append (list k v)))
          (output nil))
@@ -2475,11 +2475,11 @@ Uses `duckdb-query--substitute-var-refs' for @var: and @expr: replacement."
                ;; DDL/DML success - non-JSON, non-error output
                (t nil)))))
       ;; Cleanup: reset variables in session mode
-      (when (and (or var expr) (eq executor :session))
+      (when (and (or val expr) (eq executor :session))
         (ignore-errors
           (duckdb-query-session-execute
            duckdb-query--current-session
-           (duckdb-query--var-reset-sql (or var '()) (or expr '()))
+           (duckdb-query--var-reset-sql (or val '()) (or expr '()))
            5)))
       ;; Cleanup temp files
       (maphash (lambda (_sym file)

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -2128,12 +2128,15 @@ Also see `duckdb-query--substitute-var-refs' for variable setup."
 
 SQL-BINDINGS is alist of (name . sql-fragment) pairs.
 Each @sql:NAME reference is replaced with the corresponding fragment.
-Users should wrap references in parentheses when used as subqueries:
-  FROM (@sql:base)  =>  FROM (SELECT * FROM users)
+
+Substitution iterates until no @sql: references remain, resolving
+nested fragment references regardless of declaration order.
+
+Signals `user-error' if @sql:NAME appears but NAME is not in
+SQL-BINDINGS.  Signals `user-error' if iteration limit is exceeded,
+indicating circular references.
 
 Returns modified query string.
-
-Signals =user-error' if @sql:NAME appears but NAME is not in SQL-BINDINGS.
 
 Example:
   (duckdb-query--substitute-sql-refs
@@ -2141,29 +2144,39 @@ Example:
    \\='((base . \"SELECT id, name FROM users\")))
   => \"SELECT * FROM (SELECT id, name FROM users) WHERE x > 1\"
 
-Called by =duckdb-query' before other reference substitutions."
+Called by `duckdb-query' before other reference substitutions."
   (let ((result query)
-        (sql-ref-pattern "@sql:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
-    ;; Collect all @sql: references first to validate
-    (let ((refs nil)
-          (temp-query query))
-      (while (string-match sql-ref-pattern temp-query)
-        (push (intern (match-string 1 temp-query)) refs)
-        (setq temp-query (substring temp-query (match-end 0))))
-      ;; Validate all references exist in bindings
-      (dolist (ref (nreverse refs))
-        (unless (assq ref sql-bindings)
-          (user-error "@sql:%s in query but '%s' not found in :sql parameter"
-                      ref ref))))
-    ;; Perform substitutions - direct text replacement, no wrapping
-    (dolist (binding sql-bindings)
-      (let* ((name (symbol-name (car binding)))
-             (fragment (cdr binding))
-             (pattern (format "@sql:%s\\b" (regexp-quote name))))
-        (setq result (replace-regexp-in-string
-                      pattern
-                      fragment
-                      result t t))))
+        (sql-ref-pattern "@sql:\\([a-zA-Z_][a-zA-Z0-9_]*\\)")
+        (max-iterations (1+ (length sql-bindings)))
+        (iteration 0))
+    ;; Iteratively substitute until no @sql: references remain.
+    ;; Each pass may reveal new references from spliced fragments.
+    (while (and (< iteration max-iterations)
+                (string-match-p sql-ref-pattern result))
+      (cl-incf iteration)
+      ;; Validate all current references exist in bindings
+      (let ((temp-query result)
+            (refs nil))
+        (while (string-match sql-ref-pattern temp-query)
+          (push (intern (match-string 1 temp-query)) refs)
+          (setq temp-query (substring temp-query (match-end 0))))
+        (dolist (ref (nreverse refs))
+          (unless (assq ref sql-bindings)
+            (user-error "@sql:%s in query but '%s' not found in :sql parameter"
+                        ref ref))))
+      ;; Perform one pass of substitutions
+      (dolist (binding sql-bindings)
+        (let* ((name (symbol-name (car binding)))
+               (fragment (cdr binding))
+               (pattern (format "@sql:%s\\b" (regexp-quote name))))
+          (setq result (replace-regexp-in-string
+                        pattern
+                        fragment
+                        result t t)))))
+    ;; Check for unresolved references after all iterations
+    (when (string-match-p sql-ref-pattern result)
+      (user-error "Circular @sql: references detected; resolution did not converge after %d iterations"
+                  max-iterations))
     result))
 
 

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -1498,34 +1498,6 @@ Example:
     (error "Symbol %S is not a function" executor))
   (apply executor query args))
 
-;;;; Low-Level Execution
-(defun duckdb-query-execute-raw (query &optional database _timeout)
-  "Execute QUERY via DuckDB CLI and return raw JSON string.
-
-This is the low-level execution primitive.  Most code should use
-`duckdb-query' or `duckdb-query-execute' instead.
-
-QUERY is SQL string.
-DATABASE is optional path to database file; nil uses in-memory.
-TIMEOUT is reserved for future use; currently ignored.
-
-Return raw JSON output string for parsing.
-Signal error on non-zero exit code.
-
-Use `duckdb-query-executable' for subprocess invocation.
-Wrapped by `duckdb-query-execute' `:cli' method."
-  (with-temp-buffer
-    (let* ((cmd (if database
-                    (list duckdb-query-executable database "-json" "-c" query)
-                  (list duckdb-query-executable "-json" "-c" query)))
-           (default-directory temporary-file-directory)
-           (process-environment (cons "DUCKDB_NO_COLOR=1" process-environment)))
-      (let ((exit-code (apply #'call-process (car cmd) nil t nil (cdr cmd))))
-        (if (zerop exit-code)
-            (buffer-string)
-          (error "DuckDB execution failed (exit %d): %s"
-                 exit-code (string-trim (buffer-string))))))))
-
 ;;;; Format Conversion
 ;;;;; Columnar Format
 

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -2016,45 +2016,76 @@ result))
 ;;;;; Variable Reference Substitution
 
 (defun duckdb-query--substitute-var-refs (query var-bindings)
-  "Replace @var:NAME references in QUERY with call to getvariable().
+  "Replace @var:NAME and @expr:NAME references in QUERY.
 
-QUERY is SQL string potentially containing @var:NAME references.
+QUERY is SQL string potentially containing references:
+  @var:NAME  - Literal value, quoted appropriately
+  @expr:NAME - SQL expression, passed through unquoted
+
 VAR-BINDINGS is alist of (name . value) pairs from :var parameter.
+Values are treated as literals for @var: references and as SQL
+expressions for @expr: references.
 
 Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
-  SUBSTITUTED-QUERY has @var:NAME replaced with getvariable('NAME')
-  VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
-
-Variables are set before query execution and should be reset after
-via `duckdb-query--var-reset-sql'.
+SUBSTITUTED-QUERY has references replaced with getvariable('NAME')
+VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
 
 Example:
   (duckdb-query--substitute-var-refs
-   \"SELECT * FROM t WHERE x > @var:threshold\"
-   \\='((threshold . 100)))
-  => (\"SELECT * FROM t WHERE x > getvariable('threshold')\"
-      . \"SET VARIABLE threshold = 100;\\n\")"
+   \"SELECT @var:x, @expr:y\"
+   \\='((x . 100) (y . \"(SELECT 1 + 1)\")))
+  => (\"SELECT getvariable('x'), getvariable('y')\"
+      . \"SET VARIABLE x = 100;\\nSET VARIABLE y = (SELECT 1 + 1);\\n\")"
   (let ((result query)
         (setup-sql "")
-        (var-ref-pattern "@var:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
-    ;; Build SET VARIABLE statements for all bindings
-    (dolist (binding var-bindings)
-      (let* ((name (symbol-name (car binding)))
-             (value (cdr binding))
-             (sql-value (duckdb-query--value-to-sql-literal value)))
-        (setq setup-sql
-              (concat setup-sql
-                      (format "SET VARIABLE %s = %s;\n" name sql-value)))))
-    ;; Replace @var:NAME with getvariable('NAME')
-    (while (string-match var-ref-pattern result)
-      (let ((var-name (match-string 1 result)))
-        ;; Verify binding exists
-        (unless (assq (intern var-name) var-bindings)
-          (error "Variable @var:%s referenced but not bound in :var parameter"
-                 var-name))
-        (setq result (replace-match
-                      (format "getvariable('%s')" var-name)
-                      t t result))))
+        (used-vars nil)
+        ;; Pattern for @var:NAME (literal binding)
+        (var-ref-pattern "@var:\\([a-zA-Z_][a-zA-Z0-9_]*\\)")
+        ;; Pattern for @expr:NAME (expression binding)
+        (expr-ref-pattern "@expr:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
+
+    ;; Collect all @var: references and replace with getvariable()
+    (let ((temp-result result))
+      (while (string-match var-ref-pattern temp-result)
+        (let ((var-name (match-string 1 temp-result)))
+          (push (cons (intern var-name) :literal) used-vars)
+          (setq temp-result (substring temp-result (match-end 0)))))
+      (setq result (replace-regexp-in-string
+                    var-ref-pattern
+                    "getvariable('\\1')"
+                    result t)))
+
+    ;; Collect all @expr: references and replace with getvariable()
+    (let ((temp-result result))
+      (while (string-match expr-ref-pattern temp-result)
+        (let ((var-name (match-string 1 temp-result)))
+          (push (cons (intern var-name) :expr) used-vars)
+          (setq temp-result (substring temp-result (match-end 0)))))
+      (setq result (replace-regexp-in-string
+                    expr-ref-pattern
+                    "getvariable('\\1')"
+                    result t)))
+
+    ;; Build SET VARIABLE statements for used bindings
+    (dolist (used (nreverse used-vars))
+      (let* ((sym (car used))
+             (ref-type (cdr used))
+             (binding (assq sym var-bindings))
+             (name (symbol-name sym)))
+        (unless binding
+          (error "Variable @%s:%s referenced but not bound in :var parameter"
+                 (if (eq ref-type :expr) "expr" "var")
+                 name))
+        (let* ((value (cdr binding))
+               (sql-value (if (eq ref-type :expr)
+                              ;; Expression: pass through as-is
+                              value
+                            ;; Literal: convert to SQL literal
+                            (duckdb-query--value-to-sql-literal value))))
+          (setq setup-sql
+                (concat setup-sql
+                        (format "SET VARIABLE %s = %s;\n" name sql-value))))))
+
     (cons result setup-sql)))
 
 (defun duckdb-query--var-reset-sql (var-bindings)
@@ -2158,14 +2189,27 @@ DATA-FORMAT controls how DATA is serialized to temporary files:
   :json - JSON array via native `json-serialize' (default)
   :csv  - CSV format for compatibility
 
-VAR binds values to @var:NAME references as SQL variables:
+VAR binds values to @var:NAME and @expr:NAME references:
 
   :var \\=`((threshold . 100)
          (pattern . \"O'Brien%\")
-         (active . t))
+         (ids . \"(SELECT list(id) FROM active_users)\"))
 
-  Variables are set via SET VARIABLE and accessed via getvariable().
-  Safe from SQL injection for any value type.
+  @var:NAME  - Value is quoted as SQL literal (safe for user input)
+  @expr:NAME - Value is passed as SQL expression (for computed values)
+
+Both reference types use getvariable() at runtime, but differ in how
+the value is set:
+
+  @var:threshold with value 100
+    => SET VARIABLE threshold = 100;
+
+  @expr:ids with value \"(SELECT list(id) FROM t)\"
+    => SET VARIABLE ids = (SELECT list(id) FROM t);
+
+Use @var: for user-provided data (strings, numbers, etc.).
+Use @expr: when the value must be computed by DuckDB (subqueries,
+aggregations, dynamic lists).
 
 PRESERVE-NESTED when non-nil and OUTPUT-VIA is `:pipe', wraps STRUCT,
 MAP, LIST, and ARRAY columns with to_json() so they return as nested

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -436,6 +436,10 @@ SPEC is either:
     and remaining elements are keyword options:
     :readonly - When non-nil, open database read-only (default nil)
 
+DuckDB creates the database file if it does not exist when opened
+writable (the default).  Use :readonly t to prevent file creation;
+DuckDB signals an error if the file is missing in read-only mode.
+
 Behavior depends on execution context:
 
 Within session scope (inside `duckdb-query-with-session'):
@@ -606,6 +610,10 @@ Also see `duckdb-query-with-transient-session' for ephemeral sessions."
   "Set default database for `duckdb-query' to PATH.
 
 If PATH is nil or empty string, use in-memory database.
+
+DuckDB creates the database file if it does not exist.  Queries
+open in writable mode unless overridden by explicit :readonly
+parameter.
 
 Return previous default database.
 
@@ -2221,6 +2229,8 @@ The reference type in QUERY must match the parameter:
 
 DATABASE is optional database file path.  When nil, uses
 `duckdb-query-default-database' if set, otherwise in-memory database.
+DuckDB creates the file if it does not exist (writable mode is the
+default).
 
 TIMEOUT is optional execution timeout in seconds.  Defaults to
 `duckdb-query-default-timeout'.

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -669,8 +669,7 @@ To implement custom executor, define method with `cl-defmethod':
     \"Execute QUERY with custom backend.\"
     ...)
 
-Called by `duckdb-query' to delegate execution.
-Also see Info node `(duckdb-query) Executors' for details."
+Called by `duckdb-query' to delegate execution."
   (error "No executor method defined for %S" executor))
 
 ;;;;; CLI Executor

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -70,10 +70,11 @@
 ;; - `duckdb-query-with-transient-session' - Ephemeral session
 ;;
 ;; Reference types in SQL strings:
-;; - @val:name   Literal value from :val parameter (safe quoting)
-;; - @data:name  Elisp data from :data parameter (serialized to JSON)
-;; - @sql:name   SQL fragment from :sql parameter (text substitution)
-;; - @org:name   Org table from current buffer
+;; - @val:name        Literal value from :val parameter (safe quoting)
+;; - @data:name       Elisp data from :data parameter (serialized to JSON)
+;; - @sql:name        SQL fragment from :sql parameter (text substitution)
+;; - @org:name        Org table from current buffer
+;; - @org:file:name   Org table from specific file
 ;;
 ;; Output formats via :format parameter:
 ;; - :alist (default), :plist, :hash, :vector, :columnar, :org-table
@@ -260,7 +261,7 @@ Also see `duckdb-query' with :format :row for inline usage."
    nil))
 
 (defun duckdb-query-column (query &rest args)
-  "Return single column from QUERY as list.
+  "Return first column from QUERY as list, or specific column via :column.
 
 QUERY is SQL string to execute.
 
@@ -306,9 +307,6 @@ Also see `duckdb-query' with :format :columnar for multiple columns."
       col-data)
      (t
       (append col-data nil)))))
-
-
-
 
 ;;;; Schema Introspection
 
@@ -1589,6 +1587,7 @@ Example:
   ;; => (((id . 1) (name . \"Alice\") (score . 95))
   ;;     ((id . 2) (name . \"Bob\") (score . 87)))
 
+Called by `duckdb-query--resolve-org-ref' for org table conversion.
 Also see `duckdb-query' with :format :org-table."
   (let ((headers (mapcar (lambda (h)
                            (if (symbolp h) h (intern h)))
@@ -1949,7 +1948,7 @@ Called by `duckdb-query--substitute-data-refs' when :data-format is :csv."
 ;;;;; Data Reference Substitution
 
 (defun duckdb-query--substitute-data-refs (query data data-format temp-files)
-"Replace @data:NAME and @NAME references in QUERY with temp file paths.
+  "Replace @data:NAME and @NAME references in QUERY with temp file paths.
 
 DATA is the :data parameter in one of these forms:
 - List of alists: bound to @data implicitly
@@ -1977,56 +1976,56 @@ Shorthand form (existing behavior):
 
 Both forms are equivalent.  Explicit form recommended when query
 contains @org: and @val: references for visual consistency."
-(let ((result query)
-    (serializer (if (eq data-format :csv)
-                    #'duckdb-query--alist-to-csv-file
-                    #'duckdb-query--alist-to-json-file))
-    (file-ext (if (eq data-format :csv) ".csv" ".json"))
-    (bindings
-        (cond
-        ;; nil -> no bindings
-        ((null data)
-        nil)
-        ;; Direct data: list of alists -> bind to 'data
-        ((and (listp data)
-            (listp (car data))
-            (consp (caar data)))
-        `((data . ,data)))
-        ;; List of bindings
-        (t
-        (mapcar
-        (lambda (binding)
-            (pcase binding
-            (`(,(and sym (pred symbolp))
-                . ,(and value (pred listp) (pred (lambda (v)
-                                                    (and v (listp (car v)) (consp (caar v)))))))
-                (cons sym value))
-            (_
-                (error "Invalid data binding: %S" binding))))
-        data)))))
-;; Substitute each binding - try explicit @data:NAME first, then @NAME
-(pcase-dolist (`(,sym . ,alist-data) bindings)
-    (let* ((sym-name (symbol-name sym))
-            ;; Pattern for explicit @data:NAME
-            (explicit-pattern (format "@data:%s\\b" (regexp-quote sym-name)))
-            ;; Pattern for shorthand @NAME
-            (shorthand-pattern (format "@%s\\b" (regexp-quote sym-name)))
-            (temp-file (make-temp-file
-                        (format "duckdb-data-%s-" sym)
-                        nil file-ext)))
-    (funcall serializer alist-data temp-file)
-    (puthash sym temp-file temp-files)
-    ;; Replace explicit form first
-    (setq result (replace-regexp-in-string
-                    explicit-pattern
-                    (format "'%s'" temp-file)
-                    result t t))
-    ;; Then replace shorthand form
-    (setq result (replace-regexp-in-string
-                    shorthand-pattern
-                    (format "'%s'" temp-file)
-                    result t t))))
-result))
+  (let ((result query)
+        (serializer (if (eq data-format :csv)
+                        #'duckdb-query--alist-to-csv-file
+                      #'duckdb-query--alist-to-json-file))
+        (file-ext (if (eq data-format :csv) ".csv" ".json"))
+        (bindings
+         (cond
+          ;; nil -> no bindings
+          ((null data)
+           nil)
+          ;; Direct data: list of alists -> bind to 'data
+          ((and (listp data)
+                (listp (car data))
+                (consp (caar data)))
+           `((data . ,data)))
+          ;; List of bindings
+          (t
+           (mapcar
+            (lambda (binding)
+              (pcase binding
+                (`(,(and sym (pred symbolp))
+                   . ,(and value (pred listp) (pred (lambda (v)
+                                                      (and v (listp (car v)) (consp (caar v)))))))
+                 (cons sym value))
+                (_
+                 (error "Invalid data binding: %S" binding))))
+            data)))))
+    ;; Substitute each binding - try explicit @data:NAME first, then @NAME
+    (pcase-dolist (`(,sym . ,alist-data) bindings)
+      (let* ((sym-name (symbol-name sym))
+             ;; Pattern for explicit @data:NAME
+             (explicit-pattern (format "@data:%s\\b" (regexp-quote sym-name)))
+             ;; Pattern for shorthand @NAME
+             (shorthand-pattern (format "@%s\\b" (regexp-quote sym-name)))
+             (temp-file (make-temp-file
+                         (format "duckdb-data-%s-" sym)
+                         nil file-ext)))
+        (funcall serializer alist-data temp-file)
+        (puthash sym temp-file temp-files)
+        ;; Replace explicit form first
+        (setq result (replace-regexp-in-string
+                      explicit-pattern
+                      (format "'%s'" temp-file)
+                      result t t))
+        ;; Then replace shorthand form
+        (setq result (replace-regexp-in-string
+                      shorthand-pattern
+                      (format "'%s'" temp-file)
+                      result t t))))
+    result))
 
 ;;;;; Variable Reference Substitution
 
@@ -2108,7 +2107,10 @@ Signals error if @val:NAME appears but NAME is not in VAL-BINDINGS."
   "Generate RESET VARIABLE statements for VAL-BINDINGS.
 
 Returns SQL string with RESET VARIABLE for each binding.
-Used in cleanup to avoid polluting session state."
+
+Called by `duckdb-query' during session cleanup to avoid
+polluting session state between queries.
+Also see `duckdb-query--substitute-var-refs' for variable setup."
   (mapconcat
    (lambda (binding)
      (format "RESET VARIABLE %s;" (symbol-name (car binding))))

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -2025,7 +2025,7 @@ result))
 ;;;;; Variable Reference Substitution
 
 (defun duckdb-query--substitute-var-refs (query val-bindings data-bindings data-format temp-files)
-  "Replace @val:NAME references in QUERY with getvariable() calls.
+  "Replace @val:NAME reference in QUERY with call to getvariable().
 
 QUERY is SQL string potentially containing @val:NAME references.
 VAL-BINDINGS is alist of (name . value) pairs for @val: references.

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -126,6 +126,53 @@ file creation.  Without this, the CLI executor defaults to read-only
 mode when a database path is specified, which fails for non-existent
 databases.")
 
+;;;; Internal Extraction Functions
+(defun duckdb-query--extract-single (rows format-name)
+  "Extract single scalar from ROWS, validating cardinality.
+
+ROWS is list of alists from JSON parsing.
+FORMAT-NAME is string for error messages (e.g., \":single format\")
+or nil for no suffix.
+
+Returns scalar value, or nil for empty results.
+Signals `user-error' if multiple rows or columns."
+  (let ((row (car rows)))
+    (cond
+     ((null rows) nil)
+     ((cdr rows)
+      (user-error "Query returned %d rows, expected 1%s"
+                  (length rows)
+                  (if format-name (format " for %s" format-name) "")))
+     ((cdr row)
+      (user-error "Query returned %d columns, expected 1%s"
+                  (length row)
+                  (if format-name (format " for %s" format-name) "")))
+     (t (cdar row)))))
+
+(defun duckdb-query--extract-row (rows format-name)
+  "Extract single row from ROWS, validating cardinality.
+
+ROWS is list of alists from JSON parsing.
+FORMAT-NAME is string for error messages or nil for no suffix.
+
+Returns row as alist, or nil for empty results.
+Signals `user-error' if multiple rows."
+  (cond
+   ((null rows) nil)
+   ((cdr rows)
+    (user-error "Query returned %d rows, expected 1%s"
+                (length rows)
+                (if format-name (format " for %s" format-name) "")))
+   (t (car rows))))
+
+(defun duckdb-query--extract-column (rows)
+  "Extract first column from ROWS as list.
+
+ROWS is list of alists from JSON parsing.
+
+Returns list of first column values, or nil for empty results."
+  (mapcar #'cdar rows))
+
 ;;;; Data Extraction Utilities
 
 (defun duckdb-query-value (query &rest args)
@@ -147,20 +194,38 @@ Example:
                       :database \"sales.db\")
   ;; => 99.95
 
-Also see `duckdb-query-column' for extracting entire columns."
-  (let* ((result (apply #'duckdb-query query :format :alist args))
-         (row (car result)))
-    (cond
-     ((null result)
-      nil)
-     ((cdr result)
-      (user-error "Query returned %d rows, expected 1"
-                  (length result)))
-     ((cdr row)
-      (user-error "Query returned %d columns, expected 1"
-                  (length row)))
-     (t
-      (cdar row)))))
+Also see `duckdb-query-column' for extracting entire columns.
+Also see `duckdb-query-row' for extracting single rows.
+Also see `duckdb-query' with :format :single for inline usage."
+  (duckdb-query--extract-single
+   (apply #'duckdb-query query :format :alist args)
+   nil))
+
+(defun duckdb-query-row (query &rest args)
+  "Return single row from QUERY as alist.
+
+QUERY is SQL string that must return exactly one row.
+ARGS are passed to `duckdb-query'.
+
+Returns the row as alist, or nil for empty results.
+
+Signals `user-error' if result has multiple rows.
+
+Example:
+
+  (duckdb-query-row \"SELECT * FROM users WHERE id = 1\")
+  ;; => ((id . 1) (name . \"Alice\") (email . \"alice@example.com\"))
+
+  (duckdb-query-row \"SELECT name, email FROM users WHERE id = @var:uid\"
+                    :var \\='((uid . 42)))
+  ;; => ((name . \"Bob\") (email . \"bob@example.com\"))
+
+Also see `duckdb-query-value' for scalar extraction.
+Also see `duckdb-query-column' for column extraction.
+Also see `duckdb-query' with :format :row for inline usage."
+  (duckdb-query--extract-row
+   (apply #'duckdb-query query :format :alist args)
+   nil))
 
 (defun duckdb-query-column (query &rest args)
   "Return single column from QUERY as list.
@@ -189,6 +254,8 @@ Example:
   ;; => [1 2 3 4 5]
 
 Also see `duckdb-query-value' for scalar extraction.
+Also see `duckdb-query-row' for single row extraction.
+Also see `duckdb-query' with :format :column for first column.
 Also see `duckdb-query' with :format :columnar for multiple columns."
   (let* ((column (plist-get args :column))
          (as-vector (plist-get args :as-vector))
@@ -207,6 +274,9 @@ Also see `duckdb-query' with :format :columnar for multiple columns."
       col-data)
      (t
       (append col-data nil)))))
+
+
+
 
 ;;;; Schema Introspection
 
@@ -2024,14 +2094,39 @@ DATABASE is optional database file path.  When nil, uses
 TIMEOUT is optional execution timeout in seconds.  Defaults to
 `duckdb-query-default-timeout'.
 
-FORMAT is output structure:
-  :alist     - list of alists (default)
-  :plist     - list of plists
-  :hash      - list of hash-tables
-  :vector    - vector of alists
-  :columnar  - alist of column vectors
-  :org-table - list of lists for `org-mode' tables
-  :raw       - unprocessed output string from executor
+FORMAT controls the return structure:
+
+  :alist      List of alists (default)
+              => (((col1 . val1) (col2 . val2)) ...)
+
+  :plist      List of plists
+              => ((:col1 val1 :col2 val2) ...)
+
+  :hash       List of hash tables
+              => (#<hash-table> #<hash-table> ...)
+
+  :vector     Vector of alists
+              => [((col1 . val1) ...) ...]
+
+  :columnar   Alist of column vectors
+              => ((col1 . [v1 v2 ...]) (col2 . [v1 v2 ...]))
+
+  :org-table  List of lists with header row
+              => ((col1 col2) (val1 val2) ...)
+
+  :single     Single scalar value
+              Signals error if query returns multiple rows or columns.
+              => value
+
+  :row        Single row as alist
+              Signals error if query returns multiple rows.
+              => ((col1 . val1) (col2 . val2) ...)
+
+  :column     Single column as list (first column if multiple)
+              => (val1 val2 val3 ...)
+
+  :raw        Unprocessed JSON string from DuckDB
+              => \"[{...}]\"
 
 EXECUTOR controls execution strategy:
   :cli       - Direct CLI invocation (default)
@@ -2046,12 +2141,13 @@ OUTPUT-VIA controls how results are transferred from DuckDB:
                use with :preserve-nested for nested types)
 
 When OUTPUT-VIA is `:file' and QUERY cannot be wrapped in
-COPY \(DDL, DML,DESCRIBE statements), automatically falls back to `:pipe'.
+COPY \(DDL, DML, DESCRIBE statements), automatically falls back to `:pipe'.
 
-DATA enables querying Elisp data structures via @SYMBOL references.
-Values must be actual data, not symbols; use backquote for variables:
+DATA enables querying Elisp data structures via @SYMBOL or @data:SYMBOL
+references.  Values must be actual data, not symbols; use backquote for
+variables:
 
-  Direct data (referenced as @data):
+  Direct data (referenced as @data or @data:data):
     :data \\='(((id . 1) (name . \"Alice\")) ...)
 
   Named bindings (use backquote with comma for variables):
@@ -2060,10 +2156,7 @@ Values must be actual data, not symbols; use backquote for variables:
 
 DATA-FORMAT controls how DATA is serialized to temporary files:
   :json - JSON array via native `json-serialize' (default)
-          Faster (~2x vs CSV), preserves nested types, handles
-          :null and :false correctly.
-  :csv  - CSV format for compatibility with tools expecting CSV.
-          Use when joining with CSV files or for debugging.
+  :csv  - CSV format for compatibility
 
 VAR binds values to @var:NAME references as SQL variables:
 
@@ -2071,63 +2164,42 @@ VAR binds values to @var:NAME references as SQL variables:
          (pattern . \"O'Brien%\")
          (active . t))
 
-  Variables are set via SET VARIABLE before query execution and
-  accessed via getvariable() in the query.  Variables are reset
-  after execution to avoid polluting session state.
-
-  Variable values support:
-    integer, float  -> numeric literal
-    string          -> quoted, escaped string (injection-safe)
-    t               -> TRUE
-    :false          -> FALSE
-    :null           -> NULL
-    vector          -> SQL list
-    alist           -> SQL struct
-
-  For query-assigned variables, use (:expr . \"SQL\"):
-    :var \\=`((file_list . (:expr . \"SELECT list(file) FROM files\")))
+  Variables are set via SET VARIABLE and accessed via getvariable().
+  Safe from SQL injection for any value type.
 
 PRESERVE-NESTED when non-nil and OUTPUT-VIA is `:pipe', wraps STRUCT,
 MAP, LIST, and ARRAY columns with to_json() so they return as nested
 Elisp structures instead of string representations.
-
-When OUTPUT-VIA is `:file' (the default), nested types serialize
-correctly without this parameter.  PRESERVE-NESTED is only needed
-when explicitly using `:output-via :pipe'.
 
 Additional keyword arguments in ARGS are passed to EXECUTOR.
 
 Returns nil for empty results.
 Returns converted data in FORMAT for successful queries.
 
-QUERY may contain @org:NAME references to named org tables in current
-buffer, resolved via `org-babel-ref-resolve'.  Use @org:FILE:NAME for
-tables in other files.
-
 Examples:
 
-  ;; Simple query (uses fast file output by default)
+  ;; Simple query
   (duckdb-query \"SELECT 42 as answer\")
   ;; => (((answer . 42)))
 
-  ;; Nested types work automatically with file output
-  (duckdb-query \"SELECT {'x':1,'y':2}::STRUCT(x INT,y INT) as p\")
-  ;; => (((p (x . 1) (y . 2))))
+  ;; Single value extraction
+  (duckdb-query \"SELECT COUNT(*) FROM users\" :format :single)
+  ;; => 42
 
-  ;; DDL falls back to pipe automatically
-  (duckdb-query \"CREATE TABLE test (id INT)\" :readonly nil)
+  ;; Single row extraction
+  (duckdb-query \"SELECT * FROM users WHERE id = 1\" :format :row)
+  ;; => ((id . 1) (name . \"Alice\"))
 
-  ;; Explicit pipe mode with preserve-nested
-  (duckdb-query \"SELECT * FROM nested_table\"
-                :output-via :pipe
-                :preserve-nested t)
+  ;; Column extraction
+  (duckdb-query \"SELECT name FROM users\" :format :column)
+  ;; => (\"Alice\" \"Bob\" \"Carol\")
 
   ;; Variable binding for safe parameterization
   (duckdb-query \"SELECT * FROM users WHERE age >= @var:min_age\"
                 :var \\='((min_age . 18)))
 
 Uses `duckdb-query-execute' for execution dispatch.
-Uses `duckdb-query--substitute-data-refs' for @symbol replacement.
+Uses `duckdb-query--substitute-data-refs' for @data: replacement.
 Uses `duckdb-query--substitute-org-refs' for @org: replacement.
 Uses `duckdb-query--substitute-var-refs' for @var: replacement."
   (let* ((executor (duckdb-query--resolve-executor executor))
@@ -2221,8 +2293,31 @@ Uses `duckdb-query--substitute-var-refs' for @var: replacement."
                                        :array-type 'list
                                        :null-object duckdb-query-null-value
                                        :false-object duckdb-query-false-value)))
+                  (:single
+                   (duckdb-query--extract-single
+                    (json-parse-string output
+                                       :object-type 'alist
+                                       :array-type 'list
+                                       :null-object duckdb-query-null-value
+                                       :false-object duckdb-query-false-value)
+                    ":single format"))
+                  (:row
+                   (duckdb-query--extract-row
+                    (json-parse-string output
+                                       :object-type 'alist
+                                       :array-type 'list
+                                       :null-object duckdb-query-null-value
+                                       :false-object duckdb-query-false-value)
+                    ":row format"))
+                  (:column
+                   (duckdb-query--extract-column
+                    (json-parse-string output
+                                       :object-type 'alist
+                                       :array-type 'list
+                                       :null-object duckdb-query-null-value
+                                       :false-object duckdb-query-false-value)))
                   (_
-                   (error "Unknown format: %s.  Valid: :alist :plist :hash :vector :columnar :org-table :raw"
+                   (error "Unknown format: %s.  Valid: :alist :plist :hash :vector :columnar :org-table :single :row :column :raw"
                           format))))
 
                ;; DuckDB error message - signal error
@@ -2231,10 +2326,8 @@ Uses `duckdb-query--substitute-var-refs' for @var: replacement."
                  (duckdb-query--strip-ansi trimmed))
                 (error "DuckDB error: %s" (duckdb-query--strip-ansi trimmed)))
 
-               ;; DDL/DML success - non-JSON, non-error output (e.g., prompt char "D")
-               ;; Return nil to indicate successful execution with no result set
-               (t
-                nil)))))
+               ;; DDL/DML success - non-JSON, non-error output
+               (t nil)))))
       ;; Cleanup: reset variables in session mode
       (when (and var (eq executor :session))
         (ignore-errors

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -5,7 +5,7 @@
 ;; Homepage: https://github.com/gggion/duckdb-query.el
 ;; Keywords: data sql
 
-;; Package-Version: 0.8.0
+;; Package-Version: 0.7.0
 ;; Package-Requires: ((emacs "28.1"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -1667,6 +1667,7 @@ Called by `duckdb-query'."
 Handles:
   integer, float    → numeric literal
   string            → quoted string with escaped quotes
+  (sql string)      → unquoted SQL expression
   t                 → TRUE
   :false            → FALSE
   :null, nil        → NULL
@@ -1674,16 +1675,27 @@ Handles:
   alist             → SQL struct {\\='k1\\=': v1, ...}
   list              → SQL list [v1, v2, ...]
 
+Strings are quoted by default.  Use (sql string) to pass raw SQL
+expressions that DuckDB should evaluate.
+
 Examples:
-  42                  → \"42\"
-  3.14                → \"3.14\"
-  \"O\\='Brien\"         → \"\\='O\\='\\='Brien\\='\"
-  t                   → \"TRUE\"
-  :false              → \"FALSE\"
-  [1 2 3]             → \"[1, 2, 3]\"
-  ((a . 1) (b . 2))   → \"{\\='a\\=': 1, \\='b\\=': 2}\"
-  (1 2 3)             → \"[1, 2, 3]\""
+  42                      → \"42\"
+  3.14                    → \"3.14\"
+  \"O\\='Brien\"          → \"\\='O\\='\\='Brien\\='\"
+  (sql \"(SELECT 1)\")    → \"(SELECT 1)\"
+  t                       → \"TRUE\"
+  :false                  → \"FALSE\"
+  [1 2 3]                 → \"[1, 2, 3]\"
+  [\"a\" \"b\"]           → \"[\\='a\\=', \\='b\\=']\"
+  ((a . 1) (b . \"x\"))   → \"{\\='a\\=': 1, \\='b\\=': \\='x\\='}\""
   (cond
+   ;; SQL expression passthrough - (sql string)
+   ((and (consp value)
+         (eq (car value) 'sql)
+         (consp (cdr value))
+         (stringp (cadr value))
+         (null (cddr value)))
+    (cadr value))
    ;; NULL
    ((or (null value) (eq value :null))
     "NULL")
@@ -1705,7 +1717,7 @@ Examples:
    ((vectorp value)
     (format "[%s]"
             (mapconcat #'duckdb-query--value-to-sql-literal value ", ")))
-   ;; Alist - SQL struct
+   ;; Alist - SQL struct (check before general list)
    ((and (listp value)
          (consp (car value))
          (symbolp (caar value)))
@@ -2017,6 +2029,8 @@ result))
 
 QUERY is SQL string potentially containing @val:NAME references.
 VAL-BINDINGS is alist of (name . value) pairs for @val: references.
+Bindings are processed in order like `let*', so later bindings can
+reference earlier ones via @val:name syntax in (sql ...) wrapped values.
 
 Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
   SUBSTITUTED-QUERY has references replaced with getvariable('NAME')
@@ -2026,37 +2040,62 @@ Signals error if @val:NAME appears but NAME is not in VAL-BINDINGS.
 
 Example:
   (duckdb-query--substitute-var-refs
-   \"SELECT * FROM t WHERE x > @val:threshold\"
-   \\='((threshold . 100)))
-  => (\"SELECT * FROM t WHERE x > getvariable('threshold')\"
-      . \"SET VARIABLE threshold = 100;\\n\")"
+   \"SELECT @val:x3 AS result\"
+   \\='((x1 . 10)
+     (x2 . (sql \"(SELECT @val:x1 * 2)\"))
+     (x3 . (sql \"(SELECT @val:x2 + 5)\"))))
+  => (\"SELECT getvariable('x3') AS result\"
+      . \"SET VARIABLE x1 = 10;
+SET VARIABLE x2 = (SELECT getvariable('x1') * 2);
+SET VARIABLE x3 = (SELECT getvariable('x2') + 5);
+\")"
   (let ((result query)
         (setup-sql "")
-        (val-refs nil)
+        (defined-vars nil)
         (val-ref-pattern "@val:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
 
-    ;; Collect all @val: references
-    (let ((temp-result result))
-      (while (string-match val-ref-pattern temp-result)
-        (let ((var-name (match-string 1 temp-result)))
-          (push (intern var-name) val-refs)
-          (setq temp-result (substring temp-result (match-end 0)))))
-      (setq result (replace-regexp-in-string
-                    val-ref-pattern
-                    "getvariable('\\1')"
-                    result t)))
+    ;; Process bindings in order (let* semantics)
+    (dolist (binding val-bindings)
+      (let* ((sym (car binding))
+             (name (symbol-name sym))
+             (raw-value (cdr binding))
+             ;; Check if this is a (sql ...) expression that may contain @val: refs
+             (is-sql-expr (and (consp raw-value)
+                               (eq (car raw-value) 'sql)
+                               (consp (cdr raw-value))
+                               (stringp (cadr raw-value))))
+             ;; Substitute @val: refs in sql expressions
+             (processed-value
+              (if is-sql-expr
+                  (let ((v (cadr raw-value)))
+                    (while (string-match val-ref-pattern v)
+                      (let ((ref-name (match-string 1 v)))
+                        (unless (member (intern ref-name) defined-vars)
+                          (error "@val:%s in value references undefined variable '%s'"
+                                 name ref-name))
+                        (setq v (replace-match
+                                 (format "getvariable('%s')" ref-name)
+                                 t t v))))
+                    (list 'sql v))
+                raw-value)))
+        ;; Add to setup SQL
+        (setq setup-sql
+              (concat setup-sql
+                      (format "SET VARIABLE %s = %s;\n"
+                              name
+                              (duckdb-query--value-to-sql-literal processed-value))))
+        ;; Track defined variable
+        (push sym defined-vars)))
 
-    ;; Validate and build SET VARIABLE for @val: references
-    (dolist (sym (delete-dups (nreverse val-refs)))
-      (let ((name (symbol-name sym)))
-        (if (not (assq sym val-bindings))
-            (error "@val:%s in query but '%s' not found in :val parameter" name name)
-          (let ((value (cdr (assq sym val-bindings))))
-            (setq setup-sql
-                  (concat setup-sql
-                          (format "SET VARIABLE %s = %s;\n"
-                                  name
-                                  (duckdb-query--value-to-sql-literal value))))))))
+    ;; Substitute @val: refs in main query
+    (while (string-match val-ref-pattern result)
+      (let ((ref-name (match-string 1 result)))
+        (unless (member (intern ref-name) defined-vars)
+          (error "@val:%s in query but '%s' not found in :val parameter"
+                 ref-name ref-name))
+        (setq result (replace-match
+                      (format "getvariable('%s')" ref-name)
+                      t t result))))
 
     (cons result setup-sql)))
 

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -5,7 +5,7 @@
 ;; Homepage: https://github.com/gggion/duckdb-query.el
 ;; Keywords: data sql
 
-;; Package-Version: 0.7.0
+;; Package-Version: 0.8.0
 ;; Package-Requires: ((emacs "28.1"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -643,11 +643,14 @@ This is the core extension point for pluggable execution strategies.
 Implement methods for custom executors to integrate different backends
 while leveraging the unified conversion layer.
 
-EXECUTOR controls execution strategy:
-  :cli       - Direct CLI invocation (default)
+EXECUTOR controls execution strategy.  When nil (the default),
+resolves to `:session' inside `duckdb-query-with-session' scope,
+or `:cli' otherwise.  Explicit values:
+  :cli       - Direct CLI invocation
+  :session   - Persistent process (requires session scope)
   function   - Custom executor function
   symbol     - Function name as symbol
-  object     - Custom executor object with `cl-defmethod'
+  object     - Custom executor object via `cl-defmethod'
 
 QUERY is SQL string to execute.
 

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -1672,7 +1672,7 @@ Handles:
   :null, nil        → NULL
   vector            → SQL list [v1, v2, ...]
   alist             → SQL struct {\\='k1\\=': v1, ...}
-  (:expr . string)  → unquoted expression (for query assignment)
+  list              → SQL list [v1, v2, ...]
 
 Examples:
   42                  → \"42\"
@@ -1682,12 +1682,8 @@ Examples:
   :false              → \"FALSE\"
   [1 2 3]             → \"[1, 2, 3]\"
   ((a . 1) (b . 2))   → \"{\\='a\\=': 1, \\='b\\=': 2}\"
-  (:expr . \"...\")   → \"...\""
+  (1 2 3)             → \"[1, 2, 3]\""
   (cond
-   ;; Expression passthrough (for query assignment)
-   ((and (consp value)
-         (eq (car value) :expr))
-    (cdr value))
    ;; NULL
    ((or (null value) (eq value :null))
     "NULL")
@@ -1728,6 +1724,7 @@ Examples:
    ;; Fallback
    (t
     (error "Cannot convert %S to SQL literal" value))))
+
 ;;;; Nested Type Preservation
 (defun duckdb-query--nested-type-p (type-string)
   "Return non-nil if TYPE-STRING represents a nested DuckDB type.
@@ -2015,39 +2012,28 @@ result))
 
 ;;;;; Variable Reference Substitution
 
-(defun duckdb-query--substitute-var-refs (query val-bindings expr-bindings)
-  "Replace @val:NAME and @expr:NAME references in QUERY.
+(defun duckdb-query--substitute-var-refs (query val-bindings)
+  "Replace @val:NAME references in QUERY with getvariable() calls.
 
-QUERY is SQL string potentially containing references:
-  @val:NAME  - Literal value from VAL-BINDINGS, quoted appropriately
-  @expr:NAME - SQL expression from EXPR-BINDINGS, passed through unquoted
-
+QUERY is SQL string potentially containing @val:NAME references.
 VAL-BINDINGS is alist of (name . value) pairs for @val: references.
-EXPR-BINDINGS is alist of (name . sql-string) pairs for @expr: references.
 
 Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
   SUBSTITUTED-QUERY has references replaced with getvariable('NAME')
   VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
 
-Signals error if:
-  - @val:NAME appears but NAME is not in VAL-BINDINGS
-  - @expr:NAME appears but NAME is not in EXPR-BINDINGS
-  - @val:NAME appears but NAME is in EXPR-BINDINGS (wrong parameter)
-  - @expr:NAME appears but NAME is in VAL-BINDINGS (wrong parameter)
+Signals error if @val:NAME appears but NAME is not in VAL-BINDINGS.
 
 Example:
   (duckdb-query--substitute-var-refs
-   \"SELECT @val:x, @expr:y\"
-   \\='((x . 100))
-   \\='((y . \"(SELECT 1 + 1)\")))
-  => (\"SELECT getvariable('x'), getvariable('y')\"
-      . \"SET VARIABLE x = 100;\\nSET VARIABLE y = (SELECT 1 + 1);\\n\")"
+   \"SELECT * FROM t WHERE x > @val:threshold\"
+   \\='((threshold . 100)))
+  => (\"SELECT * FROM t WHERE x > getvariable('threshold')\"
+      . \"SET VARIABLE threshold = 100;\\n\")"
   (let ((result query)
         (setup-sql "")
         (val-refs nil)
-        (expr-refs nil)
-        (val-ref-pattern "@val:\\([a-zA-Z_][a-zA-Z0-9_]*\\)")
-        (expr-ref-pattern "@expr:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
+        (val-ref-pattern "@val:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
 
     ;; Collect all @val: references
     (let ((temp-result result))
@@ -2060,63 +2046,30 @@ Example:
                     "getvariable('\\1')"
                     result t)))
 
-    ;; Collect all @expr: references
-    (let ((temp-result result))
-      (while (string-match expr-ref-pattern temp-result)
-        (let ((var-name (match-string 1 temp-result)))
-          (push (intern var-name) expr-refs)
-          (setq temp-result (substring temp-result (match-end 0)))))
-      (setq result (replace-regexp-in-string
-                    expr-ref-pattern
-                    "getvariable('\\1')"
-                    result t)))
-
     ;; Validate and build SET VARIABLE for @val: references
-    (dolist (sym (nreverse val-refs))
+    (dolist (sym (delete-dups (nreverse val-refs)))
       (let ((name (symbol-name sym)))
-        (cond
-         ((assq sym expr-bindings)
-          (error "@val:%s in query but '%s' is in :expr parameter (use @expr:%s or move to :val)"
-                 name name name))
-         ((not (assq sym val-bindings))
-          (error "@val:%s in query but '%s' not found in :val parameter" name name))
-         (t
+        (if (not (assq sym val-bindings))
+            (error "@val:%s in query but '%s' not found in :val parameter" name name)
           (let ((value (cdr (assq sym val-bindings))))
             (setq setup-sql
                   (concat setup-sql
                           (format "SET VARIABLE %s = %s;\n"
                                   name
-                                  (duckdb-query--value-to-sql-literal value)))))))))
-
-    ;; Validate and build SET VARIABLE for @expr: references
-    (dolist (sym (nreverse expr-refs))
-      (let ((name (symbol-name sym)))
-        (cond
-         ((assq sym val-bindings)
-          (error "@expr:%s in query but '%s' is in :val parameter (use @val:%s or move to :expr)"
-                 name name name))
-         ((not (assq sym expr-bindings))
-          (error "@expr:%s in query but '%s' not found in :expr parameter" name name))
-         (t
-          (let ((value (cdr (assq sym expr-bindings))))
-            (setq setup-sql
-                  (concat setup-sql
-                          (format "SET VARIABLE %s = %s;\n" name value))))))))
+                                  (duckdb-query--value-to-sql-literal value))))))))
 
     (cons result setup-sql)))
 
-(defun duckdb-query--var-reset-sql (val-bindings expr-bindings)
-  "Generate RESET VARIABLE statements for VAL-BINDINGS and EXPR-BINDINGS.
+(defun duckdb-query--var-reset-sql (val-bindings)
+  "Generate RESET VARIABLE statements for VAL-BINDINGS.
 
 Returns SQL string with RESET VARIABLE for each binding.
 Used in cleanup to avoid polluting session state."
-  (let ((all-names (append (mapcar #'car val-bindings)
-                           (mapcar #'car expr-bindings))))
-    (mapconcat
-     (lambda (sym)
-       (format "RESET VARIABLE %s;" (symbol-name sym)))
-     all-names
-     "\n")))
+  (mapconcat
+   (lambda (binding)
+     (format "RESET VARIABLE %s;" (symbol-name (car binding))))
+   val-bindings
+   "\n"))
 
 (defun duckdb-query--substitute-sql-refs (query sql-bindings)
   "Replace @sql:NAME references in QUERY with SQL fragments.
@@ -2173,7 +2126,6 @@ Called by =duckdb-query' before other reference substitutions."
                               data
                               (data-format :json)
                               val
-                              expr
                               sql
                               preserve-nested
                               &allow-other-keys)
@@ -2185,7 +2137,6 @@ QUERY is SQL string with optional inline references:
   @org:file:name    Org table from FILE
   @data:name        Elisp data from DATA parameter
   @val:name         Literal value from VAL parameter
-  @expr:name        SQL expression from EXPR parameter
   @sql:name         Query fragment from SQL parameter
 
 DATA binds Elisp data structures to @data: references:
@@ -2206,34 +2157,23 @@ VAL binds literal values to @val:NAME references:
   Values are converted to SQL literals with proper quoting.
   Safe for user input - strings are escaped automatically.
 
-EXPR binds SQL expressions to @expr:NAME references:
-
-  :expr \\='((threshold . \"(SELECT AVG(score) FROM scores)\")
-          (ids . \"(SELECT list(id) FROM active_users)\"))
-
-  Values are passed through as raw SQL and executed.
-  Use for subqueries, aggregations, and computed values.
-
 SQL binds query fragments to @sql:NAME references:
 
-  :sql \\='((active_users . \"SELECT * FROM users WHERE status = \\='active\\='\")
-        (recent_orders . \"SELECT * FROM orders WHERE date > CURRENT_DATE - 30\"))
+  :sql \\='((base . \"SELECT * FROM users WHERE status = \\='active\\='\")
+        (cols . \"id, name, email\")
+        (threshold . \"(SELECT AVG(score) FROM scores)\"))
 
-  Fragments are substituted as parenthesized subqueries before other
-  reference types are processed.  This enables query composition without
-  string interpolation.
+  Fragments are substituted as text before other reference types
+  are processed.  Use for table names, column lists, subqueries,
+  and any SQL syntax that cannot be a literal value.
 
-  Unlike :val (which quotes values safely) and :expr (which evaluates
-  expressions), :sql performs direct text substitution.
+  Unlike :val (which quotes values safely), :sql performs direct
+  text substitution.  Only use with trusted input.
 
 The reference type in QUERY must match the parameter:
   - @val:x requires x to be in :val
-  - @expr:x requires x to be in :expr
   - @sql:x requires x to be in :sql
   Mismatches signal an error with a helpful message.
-
-Important: @expr: expressions execute BEFORE the main query.
-They cannot reference CTEs defined in the same query.
 
 DATABASE is optional database file path.  When nil, uses
 `duckdb-query-default-database' if set, otherwise in-memory database.
@@ -2317,10 +2257,6 @@ Examples:
   (duckdb-query \"SELECT * FROM users WHERE age >= @val:min_age\"
                 :val \\='((min_age . 18)))
 
-  ;; Expression binding for computed values
-  (duckdb-query \"SELECT * FROM scores WHERE val > @expr:avg\"
-                :expr \\='((avg . \"(SELECT AVG(val) FROM scores)\")))
-
   ;; SQL fragment composition
   (duckdb-query \"SELECT * FROM (@sql:base) WHERE active\"
                 :sql \\='((base . \"SELECT * FROM users\")))
@@ -2328,17 +2264,17 @@ Examples:
   ;; Combined bindings
   (duckdb-query
    \"SELECT * FROM (@sql:filtered)
-    WHERE score > @expr:threshold
+    WHERE score > @sql:threshold
       AND name LIKE @val:pattern\"
-   :sql \\='((filtered . \"SELECT * FROM users WHERE status = \\='active\\='\"))
-   :expr \\='((threshold . \"(SELECT AVG(score) FROM users)\"))
-   :val \\='((pattern . \"%smith%\")))
+   :val \\='((pattern . \"%smith%\"))
+   :sql \\='((filtered . \"SELECT * FROM users WHERE status = \\='active\\='\")
+             (threshold . \"(SELECT AVG(score) FROM users)\")))
 
 Uses `duckdb-query-execute' for execution dispatch.
 Uses `duckdb-query--substitute-sql-refs' for @sql: replacement.
 Uses `duckdb-query--substitute-data-refs' for @data: replacement.
 Uses `duckdb-query--substitute-org-refs' for @org: replacement.
-Uses `duckdb-query--substitute-var-refs' for @val: and @expr: replacement."
+Uses `duckdb-query--substitute-var-refs' for @val: replacement."
   (let* ((executor (duckdb-query--resolve-executor executor))
          (temp-files (make-hash-table :test 'eq))
          ;; Step 0: Substitute @sql: references (before all others)
@@ -2353,12 +2289,11 @@ Uses `duckdb-query--substitute-var-refs' for @val: and @expr: replacement."
                                   (duckdb-query--substitute-data-refs
                                    org-resolved-query data data-format temp-files)
                                 org-resolved-query))
-         ;; Step 3: Substitute @val: and @expr: references
-         (val-result (if (or val expr)
+         ;; Step 3: Substitute @val: references
+         (val-result (if val
                          (duckdb-query--substitute-var-refs
                           data-resolved-query
-                          (or val '())
-                          (or expr '()))
+                          val)
                        (cons data-resolved-query "")))
          (substituted-query (car val-result))
          (val-setup-sql (cdr val-result))
@@ -2374,7 +2309,7 @@ Uses `duckdb-query--substitute-var-refs' for @val: and @expr: replacement."
                        (concat val-setup-sql effective-query)))
          (db (or database duckdb-query-default-database))
          (clean-args (cl-loop for (k v) on args by #'cddr
-                              unless (memq k '(:data :data-format :val :expr
+                              unless (memq k '(:data :data-format :val
                                                :sql :preserve-nested))
                               append (list k v)))
          (output nil))
@@ -2475,11 +2410,11 @@ Uses `duckdb-query--substitute-var-refs' for @val: and @expr: replacement."
                ;; DDL/DML success - non-JSON, non-error output
                (t nil)))))
       ;; Cleanup: reset variables in session mode
-      (when (and (or val expr) (eq executor :session))
+      (when (and val (eq executor :session))
         (ignore-errors
           (duckdb-query-session-execute
            duckdb-query--current-session
-           (duckdb-query--var-reset-sql (or val '()) (or expr '()))
+           (duckdb-query--var-reset-sql val)
            5)))
       ;; Cleanup temp files
       (maphash (lambda (_sym file)

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -1589,6 +1589,75 @@ Called by `duckdb-query'."
                              (substring result match-end)))))
     result))
 
+;;;;; SQL Literal Conversion
+
+(defun duckdb-query--value-to-sql-literal (value)
+  "Convert Elisp VALUE to SQL literal string.
+
+Handles:
+  integer, float    → numeric literal
+  string            → quoted string with escaped quotes
+  t                 → TRUE
+  :false            → FALSE
+  :null, nil        → NULL
+  vector            → SQL list [v1, v2, ...]
+  alist             → SQL struct {\\='k1\\=': v1, ...}
+  (:expr . string)  → unquoted expression (for query assignment)
+
+Examples:
+  42                  → \"42\"
+  3.14                → \"3.14\"
+  \"O\\='Brien\"         → \"\\='O\\='\\='Brien\\='\"
+  t                   → \"TRUE\"
+  :false              → \"FALSE\"
+  [1 2 3]             → \"[1, 2, 3]\"
+  ((a . 1) (b . 2))   → \"{\\='a\\=': 1, \\='b\\=': 2}\"
+  (:expr . \"...\")   → \"...\""
+  (cond
+   ;; Expression passthrough (for query assignment)
+   ((and (consp value)
+         (eq (car value) :expr))
+    (cdr value))
+   ;; NULL
+   ((or (null value) (eq value :null))
+    "NULL")
+   ;; Boolean
+   ((eq value t)
+    "TRUE")
+   ((eq value :false)
+    "FALSE")
+   ;; Integer
+   ((integerp value)
+    (number-to-string value))
+   ;; Float
+   ((floatp value)
+    (number-to-string value))
+   ;; String - quote and escape internal quotes
+   ((stringp value)
+    (format "'%s'" (replace-regexp-in-string "'" "''" value)))
+   ;; Vector - SQL list
+   ((vectorp value)
+    (format "[%s]"
+            (mapconcat #'duckdb-query--value-to-sql-literal value ", ")))
+   ;; Alist - SQL struct
+   ((and (listp value)
+         (consp (car value))
+         (symbolp (caar value)))
+    (format "{%s}"
+            (mapconcat
+             (lambda (pair)
+               (format "'%s': %s"
+                       (symbol-name (car pair))
+                       (duckdb-query--value-to-sql-literal (cdr pair))))
+             value
+             ", ")))
+   ;; List (non-alist) - treat as SQL list
+   ((listp value)
+    (format "[%s]"
+            (mapconcat #'duckdb-query--value-to-sql-literal value ", ")))
+   ;; Fallback
+   (t
+    (error "Cannot convert %S to SQL literal" value))))
 ;;;; Nested Type Preservation
 (defun duckdb-query--nested-type-p (type-string)
   "Return non-nil if TYPE-STRING represents a nested DuckDB type.
@@ -1792,6 +1861,8 @@ Called by `duckdb-query--substitute-data-refs' when :data-format is :csv."
           row ",")
          "\n")))))
 
+;;;;; Data Reference Substitution
+
 (defun duckdb-query--substitute-data-refs (query data data-format temp-files)
   "Replace @SYMBOL references in QUERY with temp file paths.
 
@@ -1873,6 +1944,62 @@ Called by `duckdb-query' when DATA parameter is provided."
                       result t t))))
     result))
 
+;;;;; Variable Reference Substitution
+
+(defun duckdb-query--substitute-var-refs (query var-bindings)
+  "Replace @var:NAME references in QUERY with call to getvariable().
+
+QUERY is SQL string potentially containing @var:NAME references.
+VAR-BINDINGS is alist of (name . value) pairs from :var parameter.
+
+Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
+  SUBSTITUTED-QUERY has @var:NAME replaced with getvariable('NAME')
+  VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
+
+Variables are set before query execution and should be reset after
+via `duckdb-query--var-reset-sql'.
+
+Example:
+  (duckdb-query--substitute-var-refs
+   \"SELECT * FROM t WHERE x > @var:threshold\"
+   \\='((threshold . 100)))
+  => (\"SELECT * FROM t WHERE x > getvariable('threshold')\"
+      . \"SET VARIABLE threshold = 100;\\n\")"
+  (let ((result query)
+        (setup-sql "")
+        (var-ref-pattern "@var:\\([a-zA-Z_][a-zA-Z0-9_]*\\)"))
+    ;; Build SET VARIABLE statements for all bindings
+    (dolist (binding var-bindings)
+      (let* ((name (symbol-name (car binding)))
+             (value (cdr binding))
+             (sql-value (duckdb-query--value-to-sql-literal value)))
+        (setq setup-sql
+              (concat setup-sql
+                      (format "SET VARIABLE %s = %s;\n" name sql-value)))))
+    ;; Replace @var:NAME with getvariable('NAME')
+    (while (string-match var-ref-pattern result)
+      (let ((var-name (match-string 1 result)))
+        ;; Verify binding exists
+        (unless (assq (intern var-name) var-bindings)
+          (error "Variable @var:%s referenced but not bound in :var parameter"
+                 var-name))
+        (setq result (replace-match
+                      (format "getvariable('%s')" var-name)
+                      t t result))))
+    (cons result setup-sql)))
+
+(defun duckdb-query--var-reset-sql (var-bindings)
+  "Generate RESET VARIABLE statements for VAR-BINDINGS.
+
+Returns SQL string with RESET VARIABLE for each binding.
+Used in cleanup to avoid polluting session state."
+  (mapconcat
+   (lambda (binding)
+     (format "RESET VARIABLE %s;" (symbol-name (car binding))))
+   var-bindings
+   "\n"))
+
+
 ;;;; Main Entry Point
 
 (cl-defun duckdb-query (query &rest args &key
@@ -1883,12 +2010,14 @@ Called by `duckdb-query' when DATA parameter is provided."
                               (output-via :file)
                               data
                               (data-format :json)
+                              var
                               preserve-nested
                               &allow-other-keys)
   "Execute QUERY and return results in FORMAT.
 
 QUERY is SQL string to execute.  May contain @SYMBOL references to
-Elisp data provided via DATA parameter.
+Elisp data provided via DATA parameter, @org:NAME references to
+org tables, or @var:NAME references to SQL variables.
 
 DATABASE is optional database file path.  When nil, uses
 `duckdb-query-default-database' if set, otherwise in-memory database.
@@ -1937,6 +2066,28 @@ DATA-FORMAT controls how DATA is serialized to temporary files:
   :csv  - CSV format for compatibility with tools expecting CSV.
           Use when joining with CSV files or for debugging.
 
+VAR binds values to @var:NAME references as SQL variables:
+
+  :var \\=`((threshold . 100)
+         (pattern . \"O'Brien%\")
+         (active . t))
+
+  Variables are set via SET VARIABLE before query execution and
+  accessed via getvariable() in the query.  Variables are reset
+  after execution to avoid polluting session state.
+
+  Variable values support:
+    integer, float  -> numeric literal
+    string          -> quoted, escaped string (injection-safe)
+    t               -> TRUE
+    :false          -> FALSE
+    :null           -> NULL
+    vector          -> SQL list
+    alist           -> SQL struct
+
+  For query-assigned variables, use (:expr . \"SQL\"):
+    :var \\=`((file_list . (:expr . \"SELECT list(file) FROM files\")))
+
 PRESERVE-NESTED when non-nil and OUTPUT-VIA is `:pipe', wraps STRUCT,
 MAP, LIST, and ARRAY columns with to_json() so they return as nested
 Elisp structures instead of string representations.
@@ -1972,34 +2123,49 @@ Examples:
                 :output-via :pipe
                 :preserve-nested t)
 
+  ;; Variable binding for safe parameterization
+  (duckdb-query \"SELECT * FROM users WHERE age >= @var:min_age\"
+                :var \\='((min_age . 18)))
+
 Uses `duckdb-query-execute' for execution dispatch.
 Uses `duckdb-query--substitute-data-refs' for @symbol replacement.
-Uses `duckdb-query--substitute-org-refs' for @org: replacement."
+Uses `duckdb-query--substitute-org-refs' for @org: replacement.
+Uses `duckdb-query--substitute-var-refs' for @var: replacement."
   (let* ((executor (duckdb-query--resolve-executor executor))
          (temp-files (make-hash-table :test 'eq))
-         ;; First: resolve @org: references
+         ;; Step 1: Resolve @org: references
          (org-resolved-query (duckdb-query--substitute-org-refs query temp-files))
-         ;; Then: substitute @data references
-         (substituted-query (if data
-                                (duckdb-query--substitute-data-refs
-                                 org-resolved-query data data-format temp-files)
-                              org-resolved-query))
-         ;; Then: wrap for nested preservation (only for pipe mode)
+         ;; Step 2: Substitute @data: and @ references
+         (data-resolved-query (if data
+                                  (duckdb-query--substitute-data-refs
+                                   org-resolved-query data data-format temp-files)
+                                org-resolved-query))
+         ;; Step 3: Substitute @var: references
+         (var-result (if var
+                         (duckdb-query--substitute-var-refs data-resolved-query var)
+                       (cons data-resolved-query "")))
+         (substituted-query (car var-result))
+         (var-setup-sql (cdr var-result))
+         ;; Step 4: Wrap for nested preservation if needed
          (effective-query (if (and preserve-nested
                                    (or (eq output-via :pipe)
                                        (eq executor :session)))
                               (duckdb-query--wrap-nested-columns substituted-query)
                             substituted-query))
+         ;; Combine variable setup with query
+         (full-query (if (string-empty-p var-setup-sql)
+                         effective-query
+                       (concat var-setup-sql effective-query)))
          (db (or database duckdb-query-default-database))
          (clean-args (cl-loop for (k v) on args by #'cddr
-                              unless (memq k '(:data :data-format :preserve-nested))
+                              unless (memq k '(:data :data-format :var :preserve-nested))
                               append (list k v)))
          (output nil))
     (unwind-protect
         (progn
           (setq output (apply #'duckdb-query-execute
                               executor
-                              effective-query
+                              full-query
                               :database db
                               :timeout timeout
                               :output-via output-via
@@ -2070,6 +2236,13 @@ Uses `duckdb-query--substitute-org-refs' for @org: replacement."
                ;; Return nil to indicate successful execution with no result set
                (t
                 nil)))))
+      ;; Cleanup: reset variables in session mode
+      (when (and var (eq executor :session))
+        (ignore-errors
+          (duckdb-query-session-execute
+           duckdb-query--current-session
+           (duckdb-query--var-reset-sql var)
+           5)))
       ;; Cleanup temp files
       (maphash (lambda (_sym file)
                  (when (file-exists-p file)

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -1864,85 +1864,84 @@ Called by `duckdb-query--substitute-data-refs' when :data-format is :csv."
 ;;;;; Data Reference Substitution
 
 (defun duckdb-query--substitute-data-refs (query data data-format temp-files)
-  "Replace @SYMBOL references in QUERY with temp file paths.
+"Replace @data:NAME and @NAME references in QUERY with temp file paths.
 
 DATA is the :data parameter in one of these forms:
-  - List of alists: bound to @data implicitly
-  - Alist of (SYMBOL . VALUE) pairs: symbols become @symbol references
+- List of alists: bound to @data implicitly
+- Alist of (SYMBOL . VALUE) pairs: symbols become @data:symbol or @symbol
 
-Values must be actual alist data, not symbols to be evaluated.
-Use backquote with comma to pass lexical variables:
-
-  (let ((my-data \\='(((id . 1)))))
-    (duckdb-query \"SELECT * FROM @data\" :data \\=`((data . ,my-data))))
+Both @data:NAME (explicit) and @NAME (shorthand) are recognized.
+The explicit form is preferred for clarity when mixing reference types.
 
 DATA-FORMAT controls serialization:
-  :json - JSON array via `json-serialize' (default, faster, better types)
+  :json - JSON array via `json-serialize' (default)
   :csv  - CSV via `duckdb-query--alist-to-csv-file' (for compatibility)
 
-TEMP-FILES is hash table mapping symbols to temp file paths for
-cleanup tracking.
+TEMP-FILES is hash table mapping symbols to temp file paths for cleanup.
 
 Return modified query string.
 
 Examples:
-  Single source (implicit @data):
-    :data \\='(((id . 1) (name . \"Alice\")))
+Explicit form:
+:data \\=`((users . ,user-data))
+\"SELECT * FROM @data:users\"
 
-  Named bindings with backquote:
-    :data \\=`((orders . ,my-orders-var))
-    :data \\=`((orders . ,orders) (users . ,users))
+Shorthand form (existing behavior):
+:data \\=`((users . ,user-data))
+\"SELECT * FROM @users\"
 
-Called by `duckdb-query' when DATA parameter is provided."
-  (let ((result query)
-        (serializer (if (eq data-format :csv)
-                        #'duckdb-query--alist-to-csv-file
-                      #'duckdb-query--alist-to-json-file))
-        (file-ext (if (eq data-format :csv) ".csv" ".json"))
-        (bindings
-         (cond
-          ;; nil -> no bindings
-          ((null data)
-           nil)
-
-          ;; Direct data: list of alists -> bind to 'data
-          ;; Detect by checking if first element looks like a row (alist)
-          ;; rather than a binding (symbol . list-of-alists)
-          ((and (listp data)
-                (listp (car data))
-                (consp (caar data)))
-           `((data . ,data)))
-
-          ;; List of bindings: each should be (symbol . alist-data)
-          (t
-           (mapcar
-            (lambda (binding)
-              (pcase binding
-                (`(,(and sym (pred symbolp))
-                   . ,(and value
-                           (pred listp)
-                           (pred (lambda (v)
-                                   (and v
-                                        (listp (car v))
-                                        (consp (caar v)))))))
-                 (cons sym value))
-                (_
-                 (error "Invalid data binding: %S.  Expected (symbol . alist-data); use backquote: \\=`((sym . ,var))" binding))))
-            data)))))
-
-    ;; Substitute each binding
-    (pcase-dolist (`(,sym . ,alist-data) bindings)
-      (let* ((pattern (format "@%s\\b" (regexp-quote (symbol-name sym))))
-             (temp-file (make-temp-file
-                         (format "duckdb-data-%s-" sym)
-                         nil file-ext)))
-        (funcall serializer alist-data temp-file)
-        (puthash sym temp-file temp-files)
-        (setq result (replace-regexp-in-string
-                      pattern
-                      (format "'%s'" temp-file)
-                      result t t))))
-    result))
+Both forms are equivalent.  Explicit form recommended when query
+contains @org: and @var: references for visual consistency."
+(let ((result query)
+    (serializer (if (eq data-format :csv)
+                    #'duckdb-query--alist-to-csv-file
+                    #'duckdb-query--alist-to-json-file))
+    (file-ext (if (eq data-format :csv) ".csv" ".json"))
+    (bindings
+        (cond
+        ;; nil -> no bindings
+        ((null data)
+        nil)
+        ;; Direct data: list of alists -> bind to 'data
+        ((and (listp data)
+            (listp (car data))
+            (consp (caar data)))
+        `((data . ,data)))
+        ;; List of bindings
+        (t
+        (mapcar
+        (lambda (binding)
+            (pcase binding
+            (`(,(and sym (pred symbolp))
+                . ,(and value (pred listp) (pred (lambda (v)
+                                                    (and v (listp (car v)) (consp (caar v)))))))
+                (cons sym value))
+            (_
+                (error "Invalid data binding: %S" binding))))
+        data)))))
+;; Substitute each binding - try explicit @data:NAME first, then @NAME
+(pcase-dolist (`(,sym . ,alist-data) bindings)
+    (let* ((sym-name (symbol-name sym))
+            ;; Pattern for explicit @data:NAME
+            (explicit-pattern (format "@data:%s\\b" (regexp-quote sym-name)))
+            ;; Pattern for shorthand @NAME
+            (shorthand-pattern (format "@%s\\b" (regexp-quote sym-name)))
+            (temp-file (make-temp-file
+                        (format "duckdb-data-%s-" sym)
+                        nil file-ext)))
+    (funcall serializer alist-data temp-file)
+    (puthash sym temp-file temp-files)
+    ;; Replace explicit form first
+    (setq result (replace-regexp-in-string
+                    explicit-pattern
+                    (format "'%s'" temp-file)
+                    result t t))
+    ;; Then replace shorthand form
+    (setq result (replace-regexp-in-string
+                    shorthand-pattern
+                    (format "'%s'" temp-file)
+                    result t t))))
+result))
 
 ;;;;; Variable Reference Substitution
 

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -35,27 +35,59 @@
 ;;     (duckdb-query "SELECT * FROM 'data.csv'" :format :columnar)
 ;;     ;; => ((id . [1 2 3]) (name . ["Alice" "Bob" "Carol"]))
 ;;
+;; Inline reference syntax for binding Elisp data into SQL:
+;;
+;;     (duckdb-query "SELECT * FROM @data:users WHERE age > @val:min"
+;;                   :data `((users . ,my-data))
+;;                   :val '((min . 18)))
+;;
+;; Query fragment composition:
+;;
+;;     (duckdb-query "SELECT @sql:cols FROM (@sql:base)"
+;;                   :sql '((cols . "id, name")
+;;                          (base . "SELECT * FROM users")))
+;;
 ;; Database context management:
 ;;
 ;;     (duckdb-query-with-database "app.db"
 ;;       (duckdb-query "SELECT * FROM users"))
 ;;
+;; Session-based execution for low-latency queries:
+;;
+;;     (duckdb-query-with-transient-session
+;;       (duckdb-query "CREATE TABLE t AS SELECT 1")
+;;       (duckdb-query "SELECT * FROM t"))
+;;
 ;; The package provides:
 ;; - `duckdb-query' - Execute queries with format conversion
 ;; - `duckdb-query-value' - Extract single scalar value
+;; - `duckdb-query-row' - Extract single row as alist
 ;; - `duckdb-query-column' - Extract single column as list
 ;; - `duckdb-query-describe' - Schema introspection
 ;; - `duckdb-query-with-database' - Scoped database context
 ;; - `duckdb-query-with-transient-database' - Temporary file-based database
+;; - `duckdb-query-with-session' - Scoped session execution
+;; - `duckdb-query-with-transient-session' - Ephemeral session
+;;
+;; Reference types in SQL strings:
+;; - @val:name   Literal value from :val parameter (safe quoting)
+;; - @data:name  Elisp data from :data parameter (serialized to JSON)
+;; - @sql:name   SQL fragment from :sql parameter (text substitution)
+;; - @org:name   Org table from current buffer
 ;;
 ;; Output formats via :format parameter:
 ;; - :alist (default), :plist, :hash, :vector, :columnar, :org-table
+;; - :single, :row, :column (cardinality-enforced extraction)
+;; - :raw (unprocessed JSON string)
 ;;
 ;; Execution strategies via :executor parameter:
 ;; - :cli (default) - Direct CLI invocation
+;; - :session - Persistent process via `duckdb-query-with-session'
 ;; - function - Custom executor function
 ;; - Custom objects via `cl-defmethod'
 ;;
+;; For fontification of references, see `duckdb-query-font-lock-mode'.
+;; For completion of references and SQL, see `duckdb-query-complete-mode'.
 ;; For benchmarking, see duckdb-query-bench.el.
 ;;; Code:
 

--- a/duckdb-query.el
+++ b/duckdb-query.el
@@ -2024,31 +2024,24 @@ result))
 
 ;;;;; Variable Reference Substitution
 
-(defun duckdb-query--substitute-var-refs (query val-bindings)
+(defun duckdb-query--substitute-var-refs (query val-bindings data-bindings data-format temp-files)
   "Replace @val:NAME references in QUERY with getvariable() calls.
 
 QUERY is SQL string potentially containing @val:NAME references.
 VAL-BINDINGS is alist of (name . value) pairs for @val: references.
+DATA-BINDINGS is the :data parameter for resolving @data: in (sql ...) values.
+DATA-FORMAT is :json or :csv for data serialization.
+TEMP-FILES is hash table mapping symbols to temp file paths for cleanup.
+
 Bindings are processed in order like `let*', so later bindings can
 reference earlier ones via @val:name syntax in (sql ...) wrapped values.
+Additionally, (sql ...) values can reference @data:name bindings.
 
 Returns (SUBSTITUTED-QUERY . VAR-SETUP-SQL) where:
   SUBSTITUTED-QUERY has references replaced with getvariable('NAME')
   VAR-SETUP-SQL is SQL statements to SET VARIABLE for each binding
 
-Signals error if @val:NAME appears but NAME is not in VAL-BINDINGS.
-
-Example:
-  (duckdb-query--substitute-var-refs
-   \"SELECT @val:x3 AS result\"
-   \\='((x1 . 10)
-     (x2 . (sql \"(SELECT @val:x1 * 2)\"))
-     (x3 . (sql \"(SELECT @val:x2 + 5)\"))))
-  => (\"SELECT getvariable('x3') AS result\"
-      . \"SET VARIABLE x1 = 10;
-SET VARIABLE x2 = (SELECT getvariable('x1') * 2);
-SET VARIABLE x3 = (SELECT getvariable('x2') + 5);
-\")"
+Signals error if @val:NAME appears but NAME is not in VAL-BINDINGS."
   (let ((result query)
         (setup-sql "")
         (defined-vars nil)
@@ -2059,15 +2052,21 @@ SET VARIABLE x3 = (SELECT getvariable('x2') + 5);
       (let* ((sym (car binding))
              (name (symbol-name sym))
              (raw-value (cdr binding))
-             ;; Check if this is a (sql ...) expression that may contain @val: refs
+             ;; Check if this is a (sql ...) expression
              (is-sql-expr (and (consp raw-value)
                                (eq (car raw-value) 'sql)
                                (consp (cdr raw-value))
-                               (stringp (cadr raw-value))))
-             ;; Substitute @val: refs in sql expressions
+                               (stringp (cadr raw-value))
+                               (null (cddr raw-value))))
+             ;; Process (sql ...) expressions
              (processed-value
               (if is-sql-expr
                   (let ((v (cadr raw-value)))
+                    ;; First substitute @data: references in the sql expression
+                    (when data-bindings
+                      (setq v (duckdb-query--substitute-data-refs
+                               v data-bindings data-format temp-files)))
+                    ;; Then substitute @val: references to earlier bindings
                     (while (string-match val-ref-pattern v)
                       (let ((ref-name (match-string 1 v)))
                         (unless (member (intern ref-name) defined-vars)
@@ -2332,7 +2331,10 @@ Uses `duckdb-query--substitute-var-refs' for @val: replacement."
          (val-result (if val
                          (duckdb-query--substitute-var-refs
                           data-resolved-query
-                          val)
+                          val
+                          data          ; pass data bindings
+                          data-format   ; pass data format
+                          temp-files)   ; pass temp-files for @data: resolution
                        (cons data-resolved-query "")))
          (substituted-query (car val-result))
          (val-setup-sql (cdr val-result))


### PR DESCRIPTION
# Release Notes: v0.8.0
## Parameterized Queries

-   `@val:name` references with `:val` parameter for injection-safe literal binding via `SET VARIABLE` / `getvariable()`
-   `@sql:name` references with `:sql` parameter for query fragment composition with nested resolution
-   `@data:name` as explicit prefix form (shorthand `@name` still works)
-   `(sql ...)` wrapper in `:val` bindings for computed values and sequential dependencies (`let/` semantics)
-   `@data:` references inside `(sql ...)` expressions for data-derived thresholds
-   Strict substitution order: `@sql:` first, then `@org:`, then `@data:`, then `@val:`

## New Output Formats

-   `:single`: scalar extraction with cardinality enforcement
-   `:row`: single row as alist with cardinality enforcement
-   `:column`: first column as list
-   `:raw`: unprocessed JSON string
-   `duckdb-query-row` convenience function

## Editor Support

-   `duckdb-query-font-lock-mode`: highlights `@type:name` references inside `duckdb-query` SQL strings with validation (undefined bindings, invalid context get warning face); nine presets with live preview via `duckdb-query-font-lock-select-preset`; works in org src blocks
-   `duckdb-query-complete-mode`: completion-at-point for reference names (from parsed bindings), SQL keywords, functions, and types (cached from DuckDB metadata, `3400 candidates); static analysis candidates for CTEs, table aliases, and ~@data:` names; works with corfu, company, default UI; org src block aware
-   `duckdb-query-edit.el`: structural editing: extract selected text into `@type:name` reference with auto-created binding (`duckdb-query-edit-extract-to-val`, `extract-to-sql`, `extract-to-data`); inline references back to literal values (`duckdb-query-edit-inline-ref`, `C-u` to also remove binding); remove bindings (`duckdb-query-edit-remove-binding`)

## Structural Parser

-   `duckdb-query-parse.el`: extracts form bounds, SQL string positions, keyword parameters, binding definitions, and reference locations with validation; used by font-lock, completion, and editing modules

## Duckdb Schema Parsing into Elisp data structures

-   `duckdb-query-parse-type`: recursive descent parser for DuckDB type strings (STRUCT, MAP, LIST, ARRAY, UNION, parameterized scalars, extension types, quoted field names, arbitrary nesting)
-   `duckdb-query-column-types` consolidated with `:format` parameter: `:raw` (default, backward compatible), `:parsed` (Elisp structures), `:json`
-   `duckdb-query-type-to-json` for converting parsed types to JSON-serializable alists

## Other Changes

-   Default to writable mode for all database access; `:readonly t` now required explicitly
-   Fix order-dependent `@sql:` fragment resolution
-   Fix `@org:` reference validation in font-lock
-   Remove unused `duckdb-query-execute-raw`
-   Remove unreleased info node references from docstrings
-   Fix stale docstrings throughout
